### PR TITLE
Ensure command data is smaller than the YubiHSM2's buffer

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -24,7 +24,7 @@ pub(crate) trait Command: Serialize + DeserializeOwned + Sized {
 
 impl<C: Command> From<C> for CommandMessage {
     fn from(command: C) -> CommandMessage {
-        Self::new(C::COMMAND_TYPE, serialize(&command).unwrap())
+        Self::new(C::COMMAND_TYPE, serialize(&command).unwrap()).unwrap()
     }
 }
 

--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -185,7 +185,7 @@ impl Channel {
             self.id,
             command_data,
             &tag,
-        ))
+        )?)
     }
 
     /// Compute a message for authenticating the host to the card
@@ -567,7 +567,7 @@ mod tests {
 
         // Host sends encrypted command
         let command_ciphertext = host_channel
-            .encrypt_command(CommandMessage::new(COMMAND_TYPE, Vec::from(COMMAND_DATA)))
+            .encrypt_command(CommandMessage::new(COMMAND_TYPE, Vec::from(COMMAND_DATA)).unwrap())
             .unwrap();
 
         // Card decrypts command

--- a/src/securechannel/mod.rs
+++ b/src/securechannel/mod.rs
@@ -36,6 +36,9 @@ mod static_keys;
 /// we hardcode to 128-bit for simplicity.
 pub const KEY_SIZE: usize = 16;
 
+/// Maximum size of the message buffer
+pub const MAX_MSG_SIZE: usize = 2048;
+
 pub use self::challenge::{Challenge, CHALLENGE_SIZE};
 pub(crate) use self::channel::Channel;
 pub use self::channel::Id as SessionId;


### PR DESCRIPTION
The buffer size is 2048-bytes. Return an error if the command data is too large.