### PR TITLE
Convert MockHSM into a yubihsm::Connector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,14 @@ reqwest = { version = "0.8", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 sha2 = "0.6"
-tiny_http = { version = "0.5", optional = true }
 
 [features]
 bench = []
 default = ["reqwest-connector"]
 dalek = ["ed25519-dalek"]
-mockhsm = ["dalek", "tiny_http"]
+mockhsm = ["dalek"]
 reqwest-connector = ["reqwest"]
 
 [package.metadata.docs.rs]
+features = ["reqwest-connector", "mockhsm"]
 rustc-args = ["-Ctarget-feature=+aes"]

--- a/src/connector/mod.rs
+++ b/src/connector/mod.rs
@@ -21,8 +21,8 @@ pub trait Connector: Sized {
     fn open(connector_url: &str) -> Result<Self, Error>;
 
     /// GET /connector/status returning the result as connector::Status
-    fn status(&self) -> Result<Status, Error>;
+    fn status(&mut self) -> Result<Status, Error>;
 
     /// POST /connector/api with a given command message and return the response message
-    fn send_command(&self, cmd: Vec<u8>) -> Result<Vec<u8>, Error>;
+    fn send_command(&mut self, cmd: Vec<u8>) -> Result<Vec<u8>, Error>;
 }

--- a/src/connector/reqwest_connector.rs
+++ b/src/connector/reqwest_connector.rs
@@ -34,14 +34,14 @@ impl Connector for ReqwestConnector {
     }
 
     /// GET /connector/status returning the result as connector::Status
-    fn status(&self) -> Result<Status, Error> {
+    fn status(&mut self) -> Result<Status, Error> {
         let http_response = self.get("/connector/status")?;
         let status = String::from_utf8(http_response)?;
         Status::parse(&status)
     }
 
     /// POST /connector/api with a given command message
-    fn send_command(&self, cmd: Vec<u8>) -> Result<Vec<u8>, Error> {
+    fn send_command(&mut self, cmd: Vec<u8>) -> Result<Vec<u8>, Error> {
         self.post("/connector/api", cmd)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,4 +104,4 @@ pub use object::Origin as ObjectOrigin;
 pub use object::Type as ObjectType;
 pub use object::SequenceId;
 pub use securechannel::SessionId;
-pub use session::{Session, SessionError};
+pub use session::{AbstractSession, Session, SessionError};

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -56,7 +56,7 @@ impl<C: Connector> AbstractSession<C> {
         static_keys: StaticKeys,
         reconnect: bool,
     ) -> Result<Self, Error> {
-        let connector = C::open(connector_url)?;
+        let mut connector = C::open(connector_url)?;
         let status = connector.status()?;
 
         if status.message != CONNECTOR_STATUS_OK {
@@ -97,7 +97,7 @@ impl<C: Connector> AbstractSession<C> {
     /// Create a new encrypted session using the given connector, YubiHSM2 auth key ID, and
     /// static identity keys
     pub fn new(
-        connector: C,
+        mut connector: C,
         host_challenge: &Challenge,
         auth_key_id: ObjectId,
         static_keys: StaticKeys,
@@ -258,7 +258,7 @@ impl<C: Connector> AbstractSession<C> {
 
     /// Send a command message to the YubiHSM2 and parse the response
     /// POST /connector/api with a given command message
-    fn send_command(&self, cmd: CommandMessage) -> Result<ResponseMessage, Error> {
+    fn send_command(&mut self, cmd: CommandMessage) -> Result<ResponseMessage, Error> {
         let cmd_type = cmd.command_type;
 
         // TODO: handle reconnecting when sessions are lost


### PR DESCRIPTION
Previously MockHSM used tiny_http to implement a full-blown HTTP server.

With the `yubihsm::Connector` abstraction we can bypass reqwest and allow the client code to talk directly to the MockHSM.

This eliminates the need to use threads which should make surfacing error messages from the MockHSM much better.