### PR TITLE
Make MockHSM (and therefore all Connectors) Send-safe

### DIFF
--- a/src/connector/mod.rs
+++ b/src/connector/mod.rs
@@ -16,13 +16,13 @@ pub use self::status::Status;
 pub const USER_AGENT: &str = concat!("yubihsm.rs ", env!("CARGO_PKG_VERSION"));
 
 /// API for communicating with a yubihsm-connector
-pub trait Connector: Sized {
+pub trait Connector: Sized + Send {
     /// Open a connection to a yubihsm-connector
     fn open(connector_url: &str) -> Result<Self, Error>;
 
     /// GET /connector/status returning the result as connector::Status
-    fn status(&mut self) -> Result<Status, Error>;
+    fn status(&self) -> Result<Status, Error>;
 
     /// POST /connector/api with a given command message and return the response message
-    fn send_command(&mut self, cmd: Vec<u8>) -> Result<Vec<u8>, Error>;
+    fn send_command(&self, cmd: Vec<u8>) -> Result<Vec<u8>, Error>;
 }

--- a/src/connector/reqwest_connector.rs
+++ b/src/connector/reqwest_connector.rs
@@ -34,14 +34,14 @@ impl Connector for ReqwestConnector {
     }
 
     /// GET /connector/status returning the result as connector::Status
-    fn status(&mut self) -> Result<Status, Error> {
+    fn status(&self) -> Result<Status, Error> {
         let http_response = self.get("/connector/status")?;
         let status = String::from_utf8(http_response)?;
         Status::parse(&status)
     }
 
     /// POST /connector/api with a given command message
-    fn send_command(&mut self, cmd: Vec<u8>) -> Result<Vec<u8>, Error> {
+    fn send_command(&self, cmd: Vec<u8>) -> Result<Vec<u8>, Error> {
         self.post("/connector/api", cmd)
     }
 }

--- a/src/mockhsm/mod.rs
+++ b/src/mockhsm/mod.rs
@@ -1,0 +1,51 @@
+//! Software simulation of the `YubiHSM2` for integration testing,
+//! implemented as a `yubihsm::Connector` (skipping HTTP transport)
+//!
+//! To enable, make sure to build yubihsm.rs with the "mockhsm" feature
+
+use failure::Error;
+use std::sync::{Arc, Mutex};
+
+mod objects;
+mod state;
+
+use connector::{Connector, Status};
+use securechannel::{CommandMessage, CommandType};
+use self::state::State;
+
+/// Software simulation of a `YubiHSM2` intended for testing
+pub struct MockHSM {
+    state: Arc<Mutex<State>>,
+}
+
+impl Connector for MockHSM {
+    /// Open a connection to a yubihsm-connector
+    fn open(_url: &str) -> Result<Self, Error> {
+        Ok(Self {
+            state: Arc::new(Mutex::new(State::new())),
+        })
+    }
+
+    /// GET /connector/status returning the result as connector::Status
+    fn status(&self) -> Result<Status, Error> {
+        Ok(Status {
+            message: "OK".to_owned(),
+            serial: None,
+            version: "1.0.1".to_owned(),
+            pid: 12_345,
+        })
+    }
+
+    /// POST /connector/api with a given command message and return the response message
+    fn send_command(&self, body: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let command = CommandMessage::parse(body).unwrap();
+        let mut state = self.state.lock().unwrap();
+
+        match command.command_type {
+            CommandType::CreateSession => state.create_session(&command),
+            CommandType::AuthSession => state.authenticate_session(&command),
+            CommandType::SessionMessage => state.session_message(command),
+            unsupported => panic!("unsupported command type: {:?}", unsupported),
+        }
+    }
+}

--- a/src/mockhsm/objects.rs
+++ b/src/mockhsm/objects.rs
@@ -1,0 +1,58 @@
+//! Objects stored inside of the `MockHSM`
+
+use std::collections::HashMap;
+use rand::OsRng;
+use sha2::Sha512;
+
+use ed25519_dalek::Keypair as Ed25519Keypair;
+
+use {Algorithm, Capabilities, Domains, ObjectId, ObjectLabel, ObjectOrigin, ObjectType, SequenceId};
+
+/// Objects stored in the `MockHSM`
+#[derive(Default)]
+pub struct Objects {
+    // TODO: other object types besides Ed25519 keys
+    pub ed25519_keys: HashMap<ObjectId, Object<Ed25519Keypair>>,
+}
+
+impl Objects {
+    /// Create a new MockHSM object store
+    pub fn new() -> Self {
+        Objects {
+            ed25519_keys: HashMap::new(),
+        }
+    }
+}
+
+/// An individual object in the `MockHSM`, specialized for a given object type
+pub struct Object<T> {
+    pub value: T,
+    pub object_type: ObjectType,
+    pub algorithm: Algorithm,
+    pub capabilities: Capabilities,
+    pub delegated_capabilities: Capabilities,
+    pub domains: Domains,
+    pub length: u16,
+    pub sequence: SequenceId,
+    pub origin: ObjectOrigin,
+    pub label: ObjectLabel,
+}
+
+impl Object<Ed25519Keypair> {
+    pub fn new(label: ObjectLabel, capabilities: Capabilities, domains: Domains) -> Self {
+        let mut cspring = OsRng::new().unwrap();
+
+        Self {
+            value: Ed25519Keypair::generate::<Sha512>(&mut cspring),
+            object_type: ObjectType::Asymmetric,
+            algorithm: Algorithm::EC_ED25519,
+            capabilities,
+            delegated_capabilities: Capabilities::default(),
+            domains,
+            length: 24,
+            sequence: 1,
+            origin: ObjectOrigin::Generated,
+            label,
+        }
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -57,7 +57,7 @@ impl<C: Connector> AbstractSession<C> {
         static_keys: StaticKeys,
         reconnect: bool,
     ) -> Result<Self, Error> {
-        let mut connector = C::open(connector_url)?;
+        let connector = C::open(connector_url)?;
         let status = connector.status()?;
 
         if status.message != CONNECTOR_STATUS_OK {
@@ -98,7 +98,7 @@ impl<C: Connector> AbstractSession<C> {
     /// Create a new encrypted session using the given connector, YubiHSM2 auth key ID, and
     /// static identity keys
     pub fn new(
-        mut connector: C,
+        connector: C,
         host_challenge: &Challenge,
         auth_key_id: ObjectId,
         static_keys: StaticKeys,


### PR DESCRIPTION
The only reason `Connector` previously borrowed self mutably was for the `MockHSM` as the `reqwest`-based `Connector` implementation is thread safe to begin with.

This wraps the core `MockHSM` state in an `Arc<Mutex<State>>` which lets us explicitly bound the `Connector` trait on `Send`.

Additionally this commit refactors `MockHSM` into separate files as it has grown quite large.