### PR TITLE
Rename AbstractSession -> Session (by using default generic arg)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,5 +103,5 @@ pub use object::Label as ObjectLabel;
 pub use object::Origin as ObjectOrigin;
 pub use object::Type as ObjectType;
 pub use object::SequenceId;
-pub use securechannel::SessionId;
-pub use session::{AbstractSession, Session, SessionError};
+pub use securechannel::{SessionId, StaticKeys};
+pub use session::{Session, SessionError};

--- a/src/mockhsm/mod.rs
+++ b/src/mockhsm/mod.rs
@@ -11,6 +11,8 @@ mod state;
 
 use connector::{Connector, Status};
 use securechannel::{CommandMessage, CommandType};
+use session::{PBKDF2_ITERATIONS, PBKDF2_SALT, Session};
+use super::{ObjectId, StaticKeys};
 use self::state::State;
 
 /// Software simulation of a `YubiHSM2` intended for testing
@@ -18,12 +20,34 @@ pub struct MockHSM {
     state: Arc<Mutex<State>>,
 }
 
-impl Connector for MockHSM {
-    /// Open a connection to a yubihsm-connector
-    fn open(_url: &str) -> Result<Self, Error> {
-        Ok(Self {
+impl MockHSM {
+    /// Create a new MockHSM
+    pub fn new() -> Self {
+        Self {
             state: Arc::new(Mutex::new(State::new())),
-        })
+        }
+    }
+
+    /// Create a simulated session with a MockHSM
+    pub fn create_session(auth_key_id: ObjectId, password: &str) -> Result<Session<Self>, Error> {
+        let mockhsm = Self::default();
+        let static_keys =
+            StaticKeys::derive_from_password(password.as_bytes(), PBKDF2_SALT, PBKDF2_ITERATIONS);
+
+        Session::new(mockhsm, auth_key_id, static_keys, false)
+    }
+}
+
+impl Default for MockHSM {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Connector for MockHSM {
+    /// We don't bother to implement this
+    fn open(_url: &str) -> Result<Self, Error> {
+        panic!("use MockHSM::create_session() to open a MockHSM session");
     }
 
     /// GET /connector/status returning the result as connector::Status

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,14 +8,14 @@ extern crate sha2;
 #[cfg(feature = "dalek")]
 use sha2::Sha512;
 
-use yubihsm::{AbstractSession, Algorithm, Capabilities, Connector, Domains, ObjectId,
-              ObjectOrigin, ObjectType};
-#[cfg(not(feature = "mockhsm"))]
-use yubihsm::session::Session;
+use yubihsm::{Algorithm, Capabilities, Connector, Domains, ObjectId, ObjectOrigin, ObjectType,
+              Session};
+
 #[cfg(feature = "mockhsm")]
 use yubihsm::mockhsm::MockHSM;
 
 /// Default host/port of yubihsm-connector
+#[cfg(not(feature = "mockhsm"))]
 const DEFAULT_YUBIHSM_ADDR: &str = "http://127.0.0.1:12345";
 
 /// Default auth key ID slot
@@ -51,18 +51,14 @@ fn yubihsm_integration_test() {
 #[cfg(feature = "mockhsm")]
 #[test]
 fn mockhsm_integration_test() {
-    let mut session = AbstractSession::<MockHSM>::create_from_password(
-        DEFAULT_YUBIHSM_ADDR,
-        DEFAULT_AUTH_KEY_ID,
-        DEFAULT_PASSWORD,
-        true,
-    ).unwrap_or_else(|err| panic!("error creating session: {:?}", err));
+    let mut session = MockHSM::create_session(DEFAULT_AUTH_KEY_ID, DEFAULT_PASSWORD)
+        .unwrap_or_else(|err| panic!("error creating MockHSM session: {:?}", err));
 
     integration_tests(&mut session);
 }
 
 // Tests to be performed as part of our integration testing process
-fn integration_tests<C: Connector>(session: &mut AbstractSession<C>) {
+fn integration_tests<C: Connector>(session: &mut Session<C>) {
     // NOTE: if you are adding a new test, you may need to bump NUM_HTTP_TESTS
     // as described at the top of this file
     echo_test(session);
@@ -74,7 +70,7 @@ fn integration_tests<C: Connector>(session: &mut AbstractSession<C>) {
 }
 
 // Send a simple echo request
-fn echo_test<C: Connector>(session: &mut AbstractSession<C>) {
+fn echo_test<C: Connector>(session: &mut Session<C>) {
     let message = b"Hello, world!";
     let response = session
         .echo(message.as_ref())
@@ -84,7 +80,7 @@ fn echo_test<C: Connector>(session: &mut AbstractSession<C>) {
 }
 
 // Generate an Ed25519 key
-fn generate_asymmetric_key_test<C: Connector>(session: &mut AbstractSession<C>) {
+fn generate_asymmetric_key_test<C: Connector>(session: &mut Session<C>) {
     // Ensure the object does not already exist
     assert!(
         session
@@ -117,7 +113,7 @@ fn generate_asymmetric_key_test<C: Connector>(session: &mut AbstractSession<C>) 
 
 // Compute a signature using the Ed25519 key generated in the last test
 #[cfg(feature = "dalek")]
-fn sign_ed25519_test<C: Connector>(session: &mut AbstractSession<C>) {
+fn sign_ed25519_test<C: Connector>(session: &mut Session<C>) {
     let pubkey_response = session
         .get_pubkey(TEST_KEY_ID)
         .unwrap_or_else(|err| panic!("error getting public key: {:?}", err));
@@ -144,7 +140,7 @@ fn sign_ed25519_test<C: Connector>(session: &mut AbstractSession<C>) {
 }
 
 // List the objects in the YubiHSM2
-fn list_objects_test<C: Connector>(session: &mut AbstractSession<C>) {
+fn list_objects_test<C: Connector>(session: &mut Session<C>) {
     let response = session
         .list_objects()
         .unwrap_or_else(|err| panic!("error listing objects: {:?}", err));
@@ -155,7 +151,7 @@ fn list_objects_test<C: Connector>(session: &mut AbstractSession<C>) {
 }
 
 // Delete an object in the YubiHSM2
-fn delete_object_test<C: Connector>(session: &mut AbstractSession<C>) {
+fn delete_object_test<C: Connector>(session: &mut Session<C>) {
     // The first request to delete should succeed because the object exists
     assert!(
         session


### PR DESCRIPTION
Apparently I got confused and thought I was programming in Java