### PR TITLE
Upgrade ed25519-dalek, sha2, and pbkdf2 crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ byteorder = "1.2"
 clear_on_drop = "0.2"
 cmac = "0.1"
 constant_time_eq = "0.1"
-ed25519-dalek = { version = "= 0.6.0", optional = true, features = ["sha2"] }
+ed25519-dalek = { version = "0.6.2", optional = true, features = ["sha2"] }
 failure = "0.1"
 failure_derive = "0.1"
-hmac = "0.4"
-pbkdf2 = "0.1"
+hmac = "0.6"
+pbkdf2 = "0.2"
 rand = "0.4"
 reqwest = { version = "0.8", optional = true }
 serde = "1.0"
 serde_derive = "1.0"
-sha2 = "0.6"
+sha2 = "0.7"
 
 [features]
 bench = []


### PR DESCRIPTION
The core entangling dependency here is `digest` 0.6 -> 0.7, and is shared by both `ed25519-dalek` and `pbkdf2`, as the latter uses the `hmac` crate. This updates everything across the board, enabling the wholesale `digest` upgrade.

Just in time for `digest` 0.8 to come out too, I think!