### PR TITLE
Export HttpConfig from crate toplevel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub mod session;
 
 pub use algorithm::Algorithm;
 pub use capabilities::Capabilities;
-pub use connector::{Connector, HttpConnector};
+pub use connector::{Connector, HttpConfig, HttpConnector};
 pub use domains::Domains;
 pub use object::Id as ObjectId;
 pub use object::Label as ObjectLabel;


### PR DESCRIPTION
Makes it easier to get to, and it's one of the main structs of interest to an end-user.