### PR TITLE
Note support for Rust 1.27+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: iqlusion/rust-ci:20180602.1 # bump cache keys when modifying this
+      - image: iqlusion/rust-ci:20180626.0 # bump cache keys when modifying this
 
     steps:
       - checkout
       - restore_cache:
-          key: cache-20180602.1 # bump save_cache key below too
+          key: cache-20180626.0 # bump save_cache key below too
       - run:
           name: rustfmt
           command: |
@@ -20,23 +20,25 @@ jobs:
             cargo +$RUST_NIGHTLY_VERSION clippy --version
             cargo +$RUST_NIGHTLY_VERSION clippy --features=mockhsm
       - run:
-          name: build --no-default-features (nightly-2018-06-02)
+          name: build --no-default-features
           command: |
-            rustup run $RUST_NIGHTLY_VERSION rustc --version
-            cargo +$RUST_NIGHTLY_VERSION --version
-            cargo +$RUST_NIGHTLY_VERSION build --no-default-features
+            rustc --version
+            cargo --version
+            cargo build --no-default-features
       - run:
-          name: build (nightly-2018-06-02)
+          name: build
           command: |
-            rustup run $RUST_NIGHTLY_VERSION rustc --version
-            cargo +$RUST_NIGHTLY_VERSION --version
-            cargo +$RUST_NIGHTLY_VERSION build
+            rustc --version
+            cargo --version
+            cargo build
       - run:
-          name: test (nightly-2018-06-02)
+          name: test
           command: |
-            cargo +$RUST_NIGHTLY_VERSION test --features=mockhsm
+            rustc --version
+            cargo --version
+            cargo test --features=mockhsm
       - save_cache:
-          key: cache-20180602.1 # bump restore_cache key above too
+          key: cache-20180626.0 # bump restore_cache key above too
           paths:
             - "~/.cargo"
             - "./target"

--- a/README.md
+++ b/README.md
@@ -34,11 +34,27 @@ an HTTP(S) server which sends the commands to the YubiHSM2 hardware device over
 USB.
 
 Note that this is **NOT** an official Yubico project and is in no way supported
-or endorsed by Yubico (well, whoever runs their Twitter account
-[thinks it's awesome])
+or endorsed by Yubico (although whoever runs their Twitter account
+[thinks it's awesome]).
 
 [yubihsm-connector]: https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/
 [thinks it's awesome]: https://twitter.com/Yubico/status/971186516796915712
+
+## Prerequisites
+
+This crate builds on Rust 1.27+ and by default uses SIMD features
+which require the following RUSTFLAGS:
+
+```
+RUSTFLAGS=-Ctarget-feature=+aes`
+```
+
+You can configure your `~/.cargo/config` to always pass these flags:
+
+```toml
+[build]
+rustflags = ["-Ctarget-feature=+aes"]
+```
 
 ## Status
 
@@ -81,26 +97,6 @@ let mut session = Session::create_from_password(
 // `generate asymmetric 0 100 ed25519_test_key 1 asymmetric_sign_eddsa ed25519`
 let response = session.sign_data_eddsa(100, "Hello, world!").unwrap();
 println!("Ed25519 signature: {:?}", response.signature);
-```
-
-## Build Notes
-
-This crate depends on the `aesni` crate, which uses the new "stdsimd" API
-(which recently landed in nightly) to invoke hardware AES instructions via
-`core::arch`.
-
-To access these features, you will need both a relatively recent
-Rust nightly and to pass the following as RUSTFLAGS:
-
-```
-RUSTFLAGS=-Ctarget-feature=+aes`
-```
-
-You can configure your `~/.cargo/config` to always pass these flags:
-
-```toml
-[build]
-rustflags = ["-Ctarget-feature=+aes"]
 ```
 
 ## Contributing

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -205,8 +205,8 @@ impl Algorithm {
         })
     }
     /// Serialize algorithm ID as a byte
-    pub fn to_u8(&self) -> u8 {
-        *self as u8
+    pub fn to_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,13 @@
 //! yubihsm.rs: client for `YubiHSM2` hardware security modules
 //!
-//! # Build Notes
+//! ## Prerequisites
 //!
-//! This crate depends on the `aesni` crate, which uses the "stdsimd"
-//! API to invoke hardware AES instructions via `core::arch`.
+//! This crate builds on Rust 1.27+ and by default uses SIMD features
+//! which require the following `RUSTFLAGS`:
 //!
-//! To access these features, you will need both a relatively recent
-//! Rust nightly and to pass the following as RUSTFLAGS:
-//!
-//! `RUSTFLAGS=-Ctarget-feature=+aes`
+//! ```
+//! RUSTFLAGS=-Ctarget-feature=+aes`
+//! ```
 //!
 //! You can configure your `~/.cargo/config` to always pass these flags:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,7 @@
 //! This crate builds on Rust 1.27+ and by default uses SIMD features
 //! which require the following `RUSTFLAGS`:
 //!
-//! ```
-//! RUSTFLAGS=-Ctarget-feature=+aes`
-//! ```
+//! `RUSTFLAGS=-Ctarget-feature=+aes`
 //!
 //! You can configure your `~/.cargo/config` to always pass these flags:
 //!

--- a/src/mockhsm/state.rs
+++ b/src/mockhsm/state.rs
@@ -67,8 +67,8 @@ impl State {
         let channel = Channel::new(
             session_id,
             &self.static_keys,
-            &cmd.host_challenge,
-            &card_challenge,
+            cmd.host_challenge,
+            card_challenge,
         );
 
         let card_cryptogram = channel.card_cryptogram();
@@ -93,7 +93,7 @@ impl State {
             .unwrap_or_else(|| panic!("no session ID in command: {:?}", command.command_type));
 
         Ok(self
-            .channel(&session_id)
+            .channel(session_id)
             .verify_authenticate_session(command)
             .unwrap()
             .into())
@@ -112,7 +112,7 @@ impl State {
         });
 
         let command = self
-            .channel(&session_id)
+            .channel(session_id)
             .decrypt_command(encrypted_command)
             .unwrap();
 
@@ -128,7 +128,7 @@ impl State {
         };
 
         Ok(self
-            .channel(&session_id)
+            .channel(session_id)
             .encrypt_response(response)
             .unwrap()
             .into())
@@ -264,9 +264,9 @@ impl State {
     }
 
     /// Obtain the channel for a session by its ID
-    fn channel(&mut self, id: &SessionId) -> &mut Channel {
+    fn channel(&mut self, id: SessionId) -> &mut Channel {
         self.sessions
-            .get_mut(id)
+            .get_mut(&id)
             .unwrap_or_else(|| panic!("invalid session ID: {:?}", id))
     }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -168,8 +168,8 @@ impl Origin {
     }
 
     /// Serialize this object origin as a byte
-    pub fn to_u8(&self) -> u8 {
-        *self as u8
+    pub fn to_u8(self) -> u8 {
+        self as u8
     }
 }
 
@@ -249,8 +249,8 @@ impl Type {
     }
 
     /// Serialize this object type as a byte
-    pub fn to_u8(&self) -> u8 {
-        *self as u8
+    pub fn to_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/src/securechannel/challenge.rs
+++ b/src/securechannel/challenge.rs
@@ -32,6 +32,7 @@ impl Challenge {
     }
 
     /// Borrow the challenge value as a slice
+    #[allow(trivially_copy_pass_by_ref)]
     pub fn as_slice(&self) -> &[u8] {
         &self.0
     }

--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -44,12 +44,12 @@ impl Id {
     }
 
     /// Obtain the next session ID
-    pub fn succ(&self) -> Result<Self, SecureChannelError> {
+    pub fn succ(self) -> Result<Self, SecureChannelError> {
         Self::new(self.0 + 1)
     }
 
     /// Obtain session ID as a u8
-    pub fn to_u8(&self) -> u8 {
+    pub fn to_u8(self) -> u8 {
         self.0
     }
 }
@@ -110,8 +110,8 @@ impl Channel {
     pub fn new(
         id: Id,
         static_keys: &StaticKeys,
-        host_challenge: &Challenge,
-        card_challenge: &Challenge,
+        host_challenge: Challenge,
+        card_challenge: Challenge,
     ) -> Self {
         let context = Context::from_challenges(host_challenge, card_challenge);
         let enc_key = derive_key(&static_keys.enc_key, 0b100, &context);
@@ -550,10 +550,10 @@ mod tests {
 
         // Create channels
         let mut host_channel =
-            Channel::new(session_id, &static_keys, &host_challenge, &card_challenge);
+            Channel::new(session_id, &static_keys, host_challenge, card_challenge);
 
         let mut card_channel =
-            Channel::new(session_id, &static_keys, &host_challenge, &card_challenge);
+            Channel::new(session_id, &static_keys, host_challenge, card_challenge);
 
         // Auth host to card
         let auth_command = host_channel.authenticate_session().unwrap();

--- a/src/securechannel/command_message.rs
+++ b/src/securechannel/command_message.rs
@@ -308,14 +308,14 @@ impl CommandType {
     }
 
     /// Serialize a command as a byte
-    pub fn to_u8(&self) -> u8 {
-        *self as u8
+    pub fn to_u8(self) -> u8 {
+        self as u8
     }
 
     /// Does this command include a session ID?
     #[cfg(feature = "mockhsm")]
-    pub fn has_session_id(&self) -> bool {
-        match *self {
+    pub fn has_session_id(self) -> bool {
+        match self {
             CommandType::AuthSession | CommandType::SessionMessage => true,
             _ => false,
         }
@@ -323,8 +323,8 @@ impl CommandType {
 
     /// Does this command have a Command-MAC (C-MAC) value on the end?
     #[cfg(feature = "mockhsm")]
-    pub fn has_mac(&self) -> bool {
-        match *self {
+    pub fn has_mac(self) -> bool {
+        match self {
             CommandType::AuthSession | CommandType::SessionMessage => true,
             _ => false,
         }

--- a/src/securechannel/context.rs
+++ b/src/securechannel/context.rs
@@ -10,7 +10,7 @@ pub struct Context([u8; CONTEXT_SIZE]);
 
 impl Context {
     /// Create a derivation context from host and card challenges
-    pub fn from_challenges(host_challenge: &Challenge, card_challenge: &Challenge) -> Self {
+    pub fn from_challenges(host_challenge: Challenge, card_challenge: Challenge) -> Self {
         let mut context = [0u8; CONTEXT_SIZE];
         context[..CHALLENGE_SIZE].copy_from_slice(host_challenge.as_slice());
         context[CHALLENGE_SIZE..].copy_from_slice(card_challenge.as_slice());

--- a/src/securechannel/response_message.rs
+++ b/src/securechannel/response_message.rs
@@ -266,8 +266,8 @@ impl ResponseCode {
     }
 
     /// Convert a ResponseCode back into its original byte form
-    pub fn to_u8(&self) -> u8 {
-        let code: i8 = match *self {
+    pub fn to_u8(self) -> u8 {
+        let code: i8 = match self {
             ResponseCode::Success(cmd_type) => cmd_type as i8,
             ResponseCode::MemoryError => -1,
             ResponseCode::InitError => -2,
@@ -304,8 +304,8 @@ impl ResponseCode {
     }
 
     /// Does this response include a session ID?
-    pub fn has_session_id(&self) -> bool {
-        match *self {
+    pub fn has_session_id(self) -> bool {
+        match self {
             ResponseCode::Success(cmd_type) => match cmd_type {
                 CommandType::CreateSession | CommandType::SessionMessage => true,
                 _ => false,
@@ -314,9 +314,9 @@ impl ResponseCode {
         }
     }
 
-    /// Does this response have a Response-MAC (C-MAC) value on the end?
-    pub fn has_rmac(&self) -> bool {
-        match *self {
+    /// Does this response have a Response-MAC (R-MAC) value on the end?
+    pub fn has_rmac(self) -> bool {
+        match self {
             ResponseCode::Success(cmd_type) => match cmd_type {
                 CommandType::SessionMessage => true,
                 _ => false,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -131,8 +131,8 @@ impl<C: Connector> Session<C> {
         let channel = Channel::new(
             session_id,
             &static_keys,
-            &host_challenge,
-            &response.card_challenge,
+            host_challenge,
+            response.card_challenge,
         );
 
         // NOTE: Cryptogram implements constant-time equality comparison


### PR DESCRIPTION
Now that `core::simd` is stable, this crate supports stable Rust!

Change CI to test against stable rather than nightly, and reflect support for stable Rust in the docs.