### PR TITLE
Use the `aes` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords      = ["cryptography", "encryption", "security"]
 circle-ci = { repository = "tendermint/yubihsm-rs" }
 
 [dependencies]
-aesni = "0.3"
+aes = "0.1"
 bitflags = "1.0"
 block-modes = "0.1"
 byteorder = "1.2"
@@ -34,6 +34,7 @@ sha2 = "0.7"
 uuid = { version = "0.6", features = ["v4"] }
 
 [features]
+aes-soft = ["aes/force_soft"]
 bench = []
 default = []
 dalek = ["ed25519-dalek"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/yubihsm/0.9.0")]
 
-extern crate aesni;
+extern crate aes;
 #[macro_use]
 extern crate bitflags;
 extern crate block_modes;

--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -1,8 +1,8 @@
 //! Secure Channels using the SCP03 encrypted channel protocol
 
-use aesni::block_cipher_trait::generic_array::typenum::U16;
-use aesni::block_cipher_trait::generic_array::GenericArray;
-use aesni::{Aes128, BlockCipher};
+use aes::block_cipher_trait::generic_array::typenum::U16;
+use aes::block_cipher_trait::generic_array::GenericArray;
+use aes::{Aes128, BlockCipher};
 use block_modes::block_padding::Iso7816;
 use block_modes::{BlockMode, BlockModeIv, Cbc};
 use byteorder::{BigEndian, ByteOrder};

--- a/src/securechannel/kdf.rs
+++ b/src/securechannel/kdf.rs
@@ -2,7 +2,7 @@
 //! counter mode KDF as described in NIST SP 800-108 (NIST 800-108)
 //! with "fixed input data" specific to the SCP03 protocol
 
-use aesni::Aes128;
+use aes::Aes128;
 use byteorder::{BigEndian, ByteOrder};
 use cmac::crypto_mac::Mac;
 use cmac::Cmac;


### PR DESCRIPTION
This crate abstractly selects either an AES-NI hardware accelerated backend or a software-backed one.

The optional `aes-soft` cargo feature can be used to enable the software-based backend.