### PR TITLE
Add a `nightly` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ bench = []
 default = []
 dalek = ["ed25519-dalek"]
 mockhsm = ["dalek"]
+nightly = ["clear_on_drop/nightly"]
 
 [package.metadata.docs.rs]
 features = ["mockhsm"]


### PR DESCRIPTION
This allows `clear_on_drop` to use an intrinsic-based implementation