### PR TITLE
Use subtle crate for constant time equality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ block-modes = "0.1"
 byteorder = "1.2"
 clear_on_drop = "0.2"
 cmac = "0.1"
-constant_time_eq = "0.1"
 failure = "0.1"
 failure_derive = "0.1"
 hmac = { version = "0.6", optional = true }
@@ -31,6 +30,7 @@ serde = "1.0"
 serde_derive = "1.0"
 ring = { version = "0.13.0-alpha5", optional = true }
 sha2 = { version = "0.7", optional = true }
+subtle = "0.7"
 untrusted = { version = "0.6", optional = true }
 uuid = { version = "0.6", features = ["v4"] }
 
@@ -42,7 +42,7 @@ aes-soft = ["aes/force_soft"]
 default = ["passwords"]
 integration = ["ring", "untrusted"]
 mockhsm = ["integration"]
-nightly = ["clear_on_drop/nightly"]
+nightly = ["clear_on_drop/nightly", "subtle/nightly"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -54,18 +54,25 @@ rustflags = ["-Ctarget-feature=+aes"]
 
 ## Supported Commands
 
-* [Authenticate Session](https://developers.yubico.com/YubiHSM2/Commands/Authenticate_Session.html)
-* [Blink](https://developers.yubico.com/YubiHSM2/Commands/Blink.html)
-* [Create Session](https://developers.yubico.com/YubiHSM2/Commands/Create_Session.html)
-* [Delete Object](https://developers.yubico.com/YubiHSM2/Commands/Delete_Object.html)
-* [Echo](https://developers.yubico.com/YubiHSM2/Commands/Echo.html)
-* [Generate Asymmetric Key](https://developers.yubico.com/YubiHSM2/Commands/Generate_Asymmetric_Key.html)
-* [Get Object Info](https://developers.yubico.com/YubiHSM2/Commands/Get_Object_Info.html)
-* [Get Pubkey](https://developers.yubico.com/YubiHSM2/Commands/Get_Pubkey.html)
-* [List Objects](https://developers.yubico.com/YubiHSM2/Commands/List_Objects.html)
-* [Session Message](https://developers.yubico.com/YubiHSM2/Commands/Session_Message.html)
-* [Sign Data ECDSA](https://developers.yubico.com/YubiHSM2/Commands/Sign_Data_Ecdsa.html)
-* [Sign Data EdDSA](https://developers.yubico.com/YubiHSM2/Commands/Sign_Data_Eddsa.html) i.e. Ed25519 signatures
+* [Blink]: Blink the YubiHSM2's LEDs (to identify it)
+* [Delete Object]: Delete an object of the given ID and type
+* [Echo]: Have the card echo an input message
+* [Generate Asymmetric Key]: Generate a new asymmetric key within the `YubiHSM2`
+* [Get Object Info]: Get information about an object
+* [Get Pubkey]: Get the public key for an asymmetric private key stored on the device
+* [List Objects]: List objects visible from the current session
+* [Sign Data ECDSA]: Compute an ECDSA signature using an HSM-backed private key
+* [Sign Data EdDSA]: Compute an Ed25519 signature using an HSM-backed private key
+
+[Blink]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.blink.html
+[Delete Object]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.delete_object.html
+[Echo]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.echo.html
+[Generate Asymmetric Key]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.echo.html
+[Get Object Info]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.get_object_info.html
+[Get Pubkey]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.get_pubkey.html
+[List Objects]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.list_objects.html
+[Sign Data ECDSA]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.sign_ecdsa_sha2.html
+[Sign Data EdDSA]: https://docs.rs/yubihsm/latest/yubihsm/commands/fn.sign_ed25519.html
 
 Adding support for additional commands is easy! See the `Contributing` section.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,6 +12,8 @@ use session::{Session, SessionError};
 use {Algorithm, Capability, Connector, Domain, ObjectId, ObjectLabel, ObjectType};
 
 /// Blink the YubiHSM2's LEDs (to identify it) for the given number of seconds
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Blink.html>
 pub fn blink<C: Connector>(
     session: &mut Session<C>,
     num_seconds: u8,
@@ -20,6 +22,8 @@ pub fn blink<C: Connector>(
 }
 
 /// Delete an object of the given ID and type
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Blink.html>
 pub fn delete_object<C: Connector>(
     session: &mut Session<C>,
     object_id: ObjectId,
@@ -32,6 +36,8 @@ pub fn delete_object<C: Connector>(
 }
 
 /// Have the card echo an input message
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Echo.html>
 pub fn echo<C, T>(session: &mut Session<C>, message: T) -> Result<EchoResponse, SessionError>
 where
     C: Connector,
@@ -43,6 +49,8 @@ where
 }
 
 /// Generate a new asymmetric key within the `YubiHSM2`
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Generate_Asymmetric_Key.html>
 pub fn generate_asymmetric_key<C: Connector>(
     session: &mut Session<C>,
     key_id: ObjectId,
@@ -61,6 +69,8 @@ pub fn generate_asymmetric_key<C: Connector>(
 }
 
 /// Get information about an object
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Get_Object_Info.html>
 pub fn get_object_info<C: Connector>(
     session: &mut Session<C>,
     object_id: ObjectId,
@@ -75,6 +85,8 @@ pub fn get_object_info<C: Connector>(
 /// Get the public key for an asymmetric key stored on the device
 ///
 /// See `GetPubKeyResponse` for more information about public key formats
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Get_Pubkey.html>
 pub fn get_pubkey<C: Connector>(
     session: &mut Session<C>,
     key_id: ObjectId,
@@ -83,6 +95,8 @@ pub fn get_pubkey<C: Connector>(
 }
 
 /// List objects visible from the current session
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/List_Objects.html>
 pub fn list_objects<C: Connector>(
     session: &mut Session<C>,
 ) -> Result<ListObjectsResponse, SessionError> {
@@ -91,6 +105,8 @@ pub fn list_objects<C: Connector>(
 }
 
 /// Compute an ECDSA signature of the SHA-256 hash of the given data with the given key ID
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Data_Ecdsa.html>
 #[cfg(feature = "sha2")]
 pub fn sign_ecdsa_sha2<C: Connector>(
     session: &mut Session<C>,
@@ -101,6 +117,8 @@ pub fn sign_ecdsa_sha2<C: Connector>(
 }
 
 /// Compute an ECDSA signature of the given fixed-sized data (i.e. digest) with the given key ID
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Data_Ecdsa.html>
 pub fn sign_ecdsa_fixed<C, T>(
     session: &mut Session<C>,
     key_id: ObjectId,
@@ -117,6 +135,8 @@ where
 }
 
 /// Compute an Ed25519 signature with the given key ID
+///
+/// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Data_Eddsa.html>
 pub fn sign_ed25519<C, T>(
     session: &mut Session<C>,
     key_id: ObjectId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
 
 #![crate_name = "yubihsm"]
 #![crate_type = "rlib"]
-#![cfg_attr(feature = "bench", feature(test))]
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/yubihsm/0.11.1")]
@@ -57,7 +56,6 @@ extern crate block_modes;
 extern crate byteorder;
 extern crate clear_on_drop;
 extern crate cmac;
-extern crate constant_time_eq;
 #[macro_use]
 extern crate failure;
 #[macro_use]
@@ -74,8 +72,7 @@ extern crate serde;
 extern crate serde_derive;
 #[cfg(feature = "sha2")]
 extern crate sha2;
-#[cfg(feature = "bench")]
-extern crate test;
+extern crate subtle;
 #[cfg(feature = "mockhsm")]
 extern crate untrusted;
 extern crate uuid;

--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -338,7 +338,10 @@ impl Channel {
         let expected_host_cryptogram = self.host_cryptogram();
         let actual_host_cryptogram = Cryptogram::from_slice(&command.data);
 
-        if expected_host_cryptogram.ct_eq(&actual_host_cryptogram).unwrap_u8() != 1 {
+        if expected_host_cryptogram
+            .ct_eq(&actual_host_cryptogram)
+            .unwrap_u8() != 1
+        {
             self.terminate();
             secure_channel_fail!(VerifyFailed, "host cryptogram mismatch!");
         }

--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -9,6 +9,8 @@ use byteorder::{BigEndian, ByteOrder};
 use clear_on_drop::clear::Clear;
 use cmac::crypto_mac::Mac as CryptoMac;
 use cmac::Cmac;
+#[cfg(feature = "mockhsm")]
+use subtle::ConstantTimeEq;
 
 use super::kdf;
 #[cfg(feature = "mockhsm")]
@@ -336,7 +338,7 @@ impl Channel {
         let expected_host_cryptogram = self.host_cryptogram();
         let actual_host_cryptogram = Cryptogram::from_slice(&command.data);
 
-        if expected_host_cryptogram != actual_host_cryptogram {
+        if expected_host_cryptogram.ct_eq(&actual_host_cryptogram).unwrap_u8() != 1 {
             self.terminate();
             secure_channel_fail!(VerifyFailed, "host cryptogram mismatch!");
         }

--- a/src/securechannel/cryptogram.rs
+++ b/src/securechannel/cryptogram.rs
@@ -1,8 +1,8 @@
 //! Authentication cryptograms (8-byte MACs) used for session verification
 
 use clear_on_drop::clear::Clear;
-use subtle::{Choice, ConstantTimeEq};
 use std::fmt;
+use subtle::{Choice, ConstantTimeEq};
 
 /// Size of a cryptogram (i.e. truncated MAC)
 pub const CRYPTOGRAM_SIZE: usize = 8;

--- a/src/securechannel/cryptogram.rs
+++ b/src/securechannel/cryptogram.rs
@@ -1,15 +1,14 @@
 //! Authentication cryptograms (8-byte MACs) used for session verification
 
-use std::fmt;
-
 use clear_on_drop::clear::Clear;
-use constant_time_eq::constant_time_eq;
+use subtle::{Choice, ConstantTimeEq};
+use std::fmt;
 
 /// Size of a cryptogram (i.e. truncated MAC)
 pub const CRYPTOGRAM_SIZE: usize = 8;
 
 /// Authentication cryptograms used to verify sessions
-#[derive(Clone, Serialize, Deserialize, Eq)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Cryptogram([u8; CRYPTOGRAM_SIZE]);
 
 impl Cryptogram {
@@ -37,9 +36,9 @@ impl fmt::Debug for Cryptogram {
     }
 }
 
-impl PartialEq for Cryptogram {
-    fn eq(&self, other: &Cryptogram) -> bool {
-        constant_time_eq(self.0.as_ref(), other.0.as_ref())
+impl ConstantTimeEq for Cryptogram {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.as_ref().ct_eq(other.0.as_ref())
     }
 }
 

--- a/src/securechannel/mac.rs
+++ b/src/securechannel/mac.rs
@@ -9,8 +9,8 @@
 use clear_on_drop::clear::Clear;
 use cmac::crypto_mac::generic_array::typenum::U16;
 use cmac::crypto_mac::generic_array::GenericArray;
-use subtle::{Choice, ConstantTimeEq};
 use std::fmt;
+use subtle::{Choice, ConstantTimeEq};
 
 use super::SecureChannelError;
 

--- a/src/securechannel/response_message.rs
+++ b/src/securechannel/response_message.rs
@@ -6,7 +6,7 @@ use byteorder::WriteBytesExt;
 use byteorder::{BigEndian, ByteOrder};
 
 /// Command responses
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct ResponseMessage {
     /// Success (for a given command type) or an error type
     pub code: ResponseCode,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -138,7 +138,11 @@ impl<C: Connector> Session<C> {
             response.card_challenge,
         );
 
-        if channel.card_cryptogram().ct_eq(&response.card_cryptogram).unwrap_u8() != 1 {
+        if channel
+            .card_cryptogram()
+            .ct_eq(&response.card_cryptogram)
+            .unwrap_u8() != 1
+        {
             session_fail!(AuthFailed, "card cryptogram mismatch!");
         }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,3 +1,5 @@
+use subtle::ConstantTimeEq;
+
 #[macro_use]
 mod error;
 
@@ -136,8 +138,7 @@ impl<C: Connector> Session<C> {
             response.card_challenge,
         );
 
-        // NOTE: Cryptogram implements constant-time equality comparison
-        if channel.card_cryptogram() != response.card_cryptogram {
+        if channel.card_cryptogram().ct_eq(&response.card_cryptogram).unwrap_u8() != 1 {
             session_fail!(AuthFailed, "card cryptogram mismatch!");
         }
 


### PR DESCRIPTION
subtle is a common dependency these days and is more actively maintained than constant_time_eq.

The RustCrypto ecosystem will likely be transitioning from constant_time_eq to subtle as well.