### PR TITLE
Have generate and put commands return an ObjectId

### DIFF
--- a/src/commands/generate_asymmetric_key.rs
+++ b/src/commands/generate_asymmetric_key.rs
@@ -17,14 +17,16 @@ pub fn generate_asymmetric_key<C: Connector>(
     domains: Domain,
     capabilities: Capability,
     algorithm: AsymmetricAlgorithm,
-) -> Result<GenAsymmetricKeyResponse, SessionError> {
-    session.send_encrypted_command(GenAsymmetricKeyCommand(GenerateKeyParams {
-        key_id,
-        label,
-        domains,
-        capabilities,
-        algorithm: algorithm.into(),
-    }))
+) -> Result<ObjectId, SessionError> {
+    session
+        .send_encrypted_command(GenAsymmetricKeyCommand(GenerateKeyParams {
+            key_id,
+            label,
+            domains,
+            capabilities,
+            algorithm: algorithm.into(),
+        }))
+        .map(|response| response.key_id)
 }
 
 /// Request parameters for `commands::generate_asymmetric_key`
@@ -37,7 +39,7 @@ impl Command for GenAsymmetricKeyCommand {
 
 /// Response from `commands::generate_asymmetric_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct GenAsymmetricKeyResponse {
+pub(crate) struct GenAsymmetricKeyResponse {
     /// ID of the key
     pub key_id: ObjectId,
 }

--- a/src/commands/generate_wrap_key.rs
+++ b/src/commands/generate_wrap_key.rs
@@ -21,17 +21,19 @@ pub fn generate_wrap_key<C: Connector>(
     capabilities: Capability,
     delegated_capabilities: Capability,
     algorithm: WrapAlgorithm,
-) -> Result<GenWrapKeyResponse, SessionError> {
-    session.send_encrypted_command(GenWrapKeyCommand {
-        params: GenerateKeyParams {
-            key_id,
-            label,
-            domains,
-            capabilities,
-            algorithm: algorithm.into(),
-        },
-        delegated_capabilities,
-    })
+) -> Result<ObjectId, SessionError> {
+    session
+        .send_encrypted_command(GenWrapKeyCommand {
+            params: GenerateKeyParams {
+                key_id,
+                label,
+                domains,
+                capabilities,
+                algorithm: algorithm.into(),
+            },
+            delegated_capabilities,
+        })
+        .map(|response| response.key_id)
 }
 
 /// Request parameters for `commands::generate_wrap_key`
@@ -50,7 +52,7 @@ impl Command for GenWrapKeyCommand {
 
 /// Response from `commands::generate_wrap_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct GenWrapKeyResponse {
+pub(crate) struct GenWrapKeyResponse {
     /// ID of the key
     pub key_id: ObjectId,
 }

--- a/src/commands/put_asymmetric_key.rs
+++ b/src/commands/put_asymmetric_key.rs
@@ -20,7 +20,7 @@ pub fn put_asymmetric_key<C: Connector, T: Into<Vec<u8>>>(
     capabilities: Capability,
     algorithm: AsymmetricAlgorithm,
     key_bytes: T,
-) -> Result<PutAsymmetricKeyResponse, SessionError> {
+) -> Result<ObjectId, SessionError> {
     let data = key_bytes.into();
 
     if data.len() != algorithm.key_len() {
@@ -33,16 +33,18 @@ pub fn put_asymmetric_key<C: Connector, T: Into<Vec<u8>>>(
         );
     }
 
-    session.send_encrypted_command(PutAsymmetricKeyCommand {
-        params: PutObjectParams {
-            id: key_id,
-            label,
-            domains,
-            capabilities,
-            algorithm: algorithm.into(),
-        },
-        data,
-    })
+    session
+        .send_encrypted_command(PutAsymmetricKeyCommand {
+            params: PutObjectParams {
+                id: key_id,
+                label,
+                domains,
+                capabilities,
+                algorithm: algorithm.into(),
+            },
+            data,
+        })
+        .map(|response| response.key_id)
 }
 
 /// Request parameters for `commands::put_asymmetric_key`
@@ -61,7 +63,7 @@ impl Command for PutAsymmetricKeyCommand {
 
 /// Response from `commands::put_asymmetric_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PutAsymmetricKeyResponse {
+pub(crate) struct PutAsymmetricKeyResponse {
     /// ID of the key
     pub key_id: ObjectId,
 }

--- a/src/commands/put_auth_key.rs
+++ b/src/commands/put_auth_key.rs
@@ -21,7 +21,7 @@ pub fn put_auth_key<C: Connector, T: Into<Vec<u8>>>(
     capabilities: Capability,
     algorithm: AuthAlgorithm,
     key_bytes: T,
-) -> Result<PutAuthKeyResponse, SessionError> {
+) -> Result<ObjectId, SessionError> {
     let data = key_bytes.into();
 
     if data.len() != AUTH_KEY_SIZE {
@@ -33,16 +33,18 @@ pub fn put_auth_key<C: Connector, T: Into<Vec<u8>>>(
         );
     }
 
-    session.send_encrypted_command(PutAuthKeyCommand {
-        params: PutObjectParams {
-            id: key_id,
-            label,
-            domains,
-            capabilities,
-            algorithm: algorithm.into(),
-        },
-        data,
-    })
+    session
+        .send_encrypted_command(PutAuthKeyCommand {
+            params: PutObjectParams {
+                id: key_id,
+                label,
+                domains,
+                capabilities,
+                algorithm: algorithm.into(),
+            },
+            data,
+        })
+        .map(|response| response.key_id)
 }
 
 /// Request parameters for `commands::put_auth_key`
@@ -61,7 +63,7 @@ impl Command for PutAuthKeyCommand {
 
 /// Response from `commands::put_auth_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PutAuthKeyResponse {
+pub(crate) struct PutAuthKeyResponse {
     /// ID of the key
     pub key_id: ObjectId,
 }

--- a/src/commands/put_hmac_key.rs
+++ b/src/commands/put_hmac_key.rs
@@ -21,7 +21,7 @@ pub fn put_hmac_key<C: Connector, T: Into<Vec<u8>>>(
     capabilities: Capability,
     algorithm: HMACAlgorithm,
     key_bytes: T,
-) -> Result<PutHMACKeyResponse, SessionError> {
+) -> Result<ObjectId, SessionError> {
     let data = key_bytes.into();
 
     if data.len() < HMAC_MIN_KEY_SIZE || data.len() > algorithm.max_key_len() {
@@ -35,16 +35,18 @@ pub fn put_hmac_key<C: Connector, T: Into<Vec<u8>>>(
         );
     }
 
-    session.send_encrypted_command(PutHMACKeyCommand {
-        params: PutObjectParams {
-            id: key_id,
-            label,
-            domains,
-            capabilities,
-            algorithm: algorithm.into(),
-        },
-        data,
-    })
+    session
+        .send_encrypted_command(PutHMACKeyCommand {
+            params: PutObjectParams {
+                id: key_id,
+                label,
+                domains,
+                capabilities,
+                algorithm: algorithm.into(),
+            },
+            data,
+        })
+        .map(|response| response.key_id)
 }
 
 /// Request parameters for `commands::put_hmac_key`
@@ -63,7 +65,7 @@ impl Command for PutHMACKeyCommand {
 
 /// Response from `commands::put_hmac_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PutHMACKeyResponse {
+pub(crate) struct PutHMACKeyResponse {
     /// ID of the key
     pub key_id: ObjectId,
 }

--- a/src/commands/put_opaque.rs
+++ b/src/commands/put_opaque.rs
@@ -18,17 +18,19 @@ pub fn put_opaque<C: Connector, T: Into<Vec<u8>>>(
     capabilities: Capability,
     algorithm: OpaqueAlgorithm,
     bytes: T,
-) -> Result<PutOpaqueResponse, SessionError> {
-    session.send_encrypted_command(PutOpaqueCommand {
-        params: PutObjectParams {
-            id: object_id,
-            label,
-            domains,
-            capabilities,
-            algorithm: algorithm.into(),
-        },
-        data: bytes.into(),
-    })
+) -> Result<ObjectId, SessionError> {
+    session
+        .send_encrypted_command(PutOpaqueCommand {
+            params: PutObjectParams {
+                id: object_id,
+                label,
+                domains,
+                capabilities,
+                algorithm: algorithm.into(),
+            },
+            data: bytes.into(),
+        })
+        .map(|response| response.object_id)
 }
 
 /// Request parameters for `commands::put_opaque`
@@ -47,7 +49,7 @@ impl Command for PutOpaqueCommand {
 
 /// Response from `commands::put_opaque`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PutOpaqueResponse {
+pub(crate) struct PutOpaqueResponse {
     /// ID of the opaque data object
     pub object_id: ObjectId,
 }

--- a/src/commands/put_otp_aead_key.rs
+++ b/src/commands/put_otp_aead_key.rs
@@ -20,7 +20,7 @@ pub fn put_otp_aead_key<C: Connector, T: Into<Vec<u8>>>(
     capabilities: Capability,
     algorithm: OTPAlgorithm,
     key_bytes: T,
-) -> Result<PutOTPAEADKeyResponse, SessionError> {
+) -> Result<ObjectId, SessionError> {
     let data = key_bytes.into();
 
     if data.len() != algorithm.key_len() {
@@ -33,16 +33,18 @@ pub fn put_otp_aead_key<C: Connector, T: Into<Vec<u8>>>(
         );
     }
 
-    session.send_encrypted_command(PutOTPAEADKeyCommand {
-        params: PutObjectParams {
-            id: key_id,
-            label,
-            domains,
-            capabilities,
-            algorithm: algorithm.into(),
-        },
-        data,
-    })
+    session
+        .send_encrypted_command(PutOTPAEADKeyCommand {
+            params: PutObjectParams {
+                id: key_id,
+                label,
+                domains,
+                capabilities,
+                algorithm: algorithm.into(),
+            },
+            data,
+        })
+        .map(|response| response.key_id)
 }
 
 /// Request parameters for `commands::put_otp_aead_key`
@@ -61,7 +63,7 @@ impl Command for PutOTPAEADKeyCommand {
 
 /// Response from `commands::put_otp_aead_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PutOTPAEADKeyResponse {
+pub(crate) struct PutOTPAEADKeyResponse {
     /// ID of the key
     pub key_id: ObjectId,
 }

--- a/src/commands/put_wrap_key.rs
+++ b/src/commands/put_wrap_key.rs
@@ -20,7 +20,7 @@ pub fn put_wrap_key<C: Connector, T: Into<Vec<u8>>>(
     delegated_capabilities: Capability,
     algorithm: WrapAlgorithm,
     key_bytes: T,
-) -> Result<PutWrapKeyResponse, SessionError> {
+) -> Result<ObjectId, SessionError> {
     let data = key_bytes.into();
 
     if data.len() != algorithm.key_len() {
@@ -33,17 +33,19 @@ pub fn put_wrap_key<C: Connector, T: Into<Vec<u8>>>(
         );
     }
 
-    session.send_encrypted_command(PutWrapKeyCommand {
-        params: PutObjectParams {
-            id: key_id,
-            label,
-            domains,
-            capabilities,
-            algorithm: algorithm.into(),
-        },
-        delegated_capabilities,
-        data,
-    })
+    session
+        .send_encrypted_command(PutWrapKeyCommand {
+            params: PutObjectParams {
+                id: key_id,
+                label,
+                domains,
+                capabilities,
+                algorithm: algorithm.into(),
+            },
+            delegated_capabilities,
+            data,
+        })
+        .map(|response| response.key_id)
 }
 
 /// Request parameters for `commands::put_wrap_key`
@@ -65,7 +67,7 @@ impl Command for PutWrapKeyCommand {
 
 /// Response from `commands::put_wrap_key`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PutWrapKeyResponse {
+pub(crate) struct PutWrapKeyResponse {
     /// ID of the key
     pub key_id: ObjectId,
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -107,7 +107,7 @@ fn generate_asymmetric_key(
 ) {
     clear_test_key_slot(session, ObjectType::AsymmetricKey);
 
-    let response = yubihsm::generate_asymmetric_key(
+    let key_id = yubihsm::generate_asymmetric_key(
         session,
         TEST_KEY_ID,
         TEST_KEY_LABEL.into(),
@@ -116,7 +116,7 @@ fn generate_asymmetric_key(
         algorithm,
     ).unwrap_or_else(|err| panic!("error generating asymmetric key: {}", err));
 
-    assert_eq!(response.key_id, TEST_KEY_ID);
+    assert_eq!(key_id, TEST_KEY_ID);
 }
 
 /// Put an asymmetric private key into the HSM
@@ -128,7 +128,7 @@ fn put_asymmetric_key<T: Into<Vec<u8>>>(
 ) {
     clear_test_key_slot(session, ObjectType::AsymmetricKey);
 
-    let response = yubihsm::put_asymmetric_key(
+    let key_id = yubihsm::put_asymmetric_key(
         session,
         TEST_KEY_ID,
         TEST_KEY_LABEL.into(),
@@ -138,7 +138,7 @@ fn put_asymmetric_key<T: Into<Vec<u8>>>(
         data,
     ).unwrap_or_else(|err| panic!("error putting asymmetric key: {}", err));
 
-    assert_eq!(response.key_id, TEST_KEY_ID);
+    assert_eq!(key_id, TEST_KEY_ID);
 }
 
 /// Generate an attestation about a key in the HSM
@@ -268,7 +268,7 @@ fn generate_wrap_key_test() {
 
     clear_test_key_slot(&mut session, ObjectType::WrapKey);
 
-    let response = yubihsm::generate_wrap_key(
+    let key_id = yubihsm::generate_wrap_key(
         &mut session,
         TEST_KEY_ID,
         TEST_KEY_LABEL.into(),
@@ -278,7 +278,7 @@ fn generate_wrap_key_test() {
         algorithm,
     ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
 
-    assert_eq!(response.key_id, TEST_KEY_ID);
+    assert_eq!(key_id, TEST_KEY_ID);
 
     let object_info = yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::WrapKey)
         .unwrap_or_else(|err| panic!("error getting object info: {}", err));
@@ -447,7 +447,7 @@ fn wrap_key_test() {
 
     clear_test_key_slot(&mut session, ObjectType::WrapKey);
 
-    let put_response = yubihsm::put_wrap_key(
+    let key_id = yubihsm::put_wrap_key(
         &mut session,
         TEST_KEY_ID,
         TEST_KEY_LABEL.into(),
@@ -457,7 +457,8 @@ fn wrap_key_test() {
         algorithm,
         AESCCM_TEST_VECTORS[0].key,
     ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
-    assert_eq!(put_response.key_id, TEST_KEY_ID);
+
+    assert_eq!(key_id, TEST_KEY_ID);
 
     // Create a key to export
     let exported_key_type = ObjectType::AsymmetricKey;


### PR DESCRIPTION
Eliminates superfluous response wrapper types from the public API