### PR TITLE
Simplify and remove unnecessary response types

### DIFF
--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -37,12 +37,12 @@ mod opaque_algorithm;
 mod otp_algorithm;
 mod wrap_algorithm;
 
-pub use self::asymmetric_algorithm::AsymmetricAlgorithm;
-pub use self::auth_algorithm::AuthAlgorithm;
-pub use self::hmac_algorithm::HMACAlgorithm;
-pub use self::opaque_algorithm::OpaqueAlgorithm;
-pub use self::otp_algorithm::OTPAlgorithm;
-pub use self::wrap_algorithm::{WrapAlgorithm, WrapNonce, WrappedData};
+pub use self::asymmetric_algorithm::*;
+pub use self::auth_algorithm::*;
+pub use self::hmac_algorithm::*;
+pub use self::opaque_algorithm::*;
+pub use self::otp_algorithm::*;
+pub use self::wrap_algorithm::*;
 
 /// Cryptographic algorithm types supported by the `YubiHSM2`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/commands/delete_object.rs
+++ b/src/commands/delete_object.rs
@@ -10,11 +10,12 @@ pub fn delete_object<C: Connector>(
     session: &mut Session<C>,
     object_id: ObjectId,
     object_type: ObjectType,
-) -> Result<DeleteObjectResponse, SessionError> {
+) -> Result<(), SessionError> {
     session.send_encrypted_command(DeleteObjectCommand {
         object_id,
         object_type,
-    })
+    })?;
+    Ok(())
 }
 
 /// Request parameters for `commands::delete_object`
@@ -33,7 +34,7 @@ impl Command for DeleteObjectCommand {
 
 /// Response from `commands::delete_object`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DeleteObjectResponse {}
+pub(crate) struct DeleteObjectResponse {}
 
 impl Response for DeleteObjectResponse {
     const COMMAND_TYPE: CommandType = CommandType::DeleteObject;

--- a/src/commands/echo.rs
+++ b/src/commands/echo.rs
@@ -6,14 +6,16 @@ use super::{Command, Response};
 use {CommandType, Connector, Session, SessionError};
 
 /// Have the card echo an input message
-pub fn echo<C, T>(session: &mut Session<C>, message: T) -> Result<EchoResponse, SessionError>
+pub fn echo<C, T>(session: &mut Session<C>, message: T) -> Result<Vec<u8>, SessionError>
 where
     C: Connector,
     T: Into<Vec<u8>>,
 {
-    session.send_encrypted_command(EchoCommand {
-        message: message.into(),
-    })
+    session
+        .send_encrypted_command(EchoCommand {
+            message: message.into(),
+        })
+        .map(|response| response.0)
 }
 
 /// Request parameters for `commands::echo`
@@ -29,53 +31,8 @@ impl Command for EchoCommand {
 
 /// Response from `commands::ccho`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct EchoResponse(pub Vec<u8>);
+pub(crate) struct EchoResponse(pub(crate) Vec<u8>);
 
 impl Response for EchoResponse {
     const COMMAND_TYPE: CommandType = CommandType::Echo;
-}
-
-impl EchoResponse {
-    /// Unwrap inner byte vector
-    #[inline]
-    pub fn into_vec(self) -> Vec<u8> {
-        self.into()
-    }
-
-    /// Get length of the echo data
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Is the echo response empty?
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Get slice of the inner byte vector
-    #[inline]
-    pub fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
-}
-
-impl AsRef<[u8]> for EchoResponse {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-#[cfg(feature = "mockhsm")]
-impl<'a> From<&'a [u8]> for EchoResponse {
-    fn from(slice: &'a [u8]) -> Self {
-        EchoResponse(slice.into())
-    }
-}
-
-impl Into<Vec<u8>> for EchoResponse {
-    fn into(self) -> Vec<u8> {
-        self.0
-    }
 }

--- a/src/commands/export_wrapped.rs
+++ b/src/commands/export_wrapped.rs
@@ -3,7 +3,7 @@
 //! <https://developers.yubico.com/YubiHSM2/Commands/Export_Wrap_Key.html>
 
 use super::{Command, Response};
-use {CommandType, Connector, ObjectId, ObjectType, Session, SessionError, WrapNonce, WrappedData};
+use {CommandType, Connector, ObjectId, ObjectType, Session, SessionError, WrapMessage};
 
 /// Export an encrypted object from the `YubiHSM2` using the given key-wrapping key
 pub fn export_wrapped<C: Connector>(
@@ -11,12 +11,14 @@ pub fn export_wrapped<C: Connector>(
     wrap_key_id: ObjectId,
     object_type: ObjectType,
     object_id: ObjectId,
-) -> Result<ExportWrappedResponse, SessionError> {
-    session.send_encrypted_command(ExportWrappedCommand {
-        wrap_key_id,
-        object_type,
-        object_id,
-    })
+) -> Result<WrapMessage, SessionError> {
+    session
+        .send_encrypted_command(ExportWrappedCommand {
+            wrap_key_id,
+            object_type,
+            object_id,
+        })
+        .map(|response| response.0)
 }
 
 /// Request parameters for `commands::export_wrapped`
@@ -38,13 +40,7 @@ impl Command for ExportWrappedCommand {
 
 /// Response from `commands::export_wrapped`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ExportWrappedResponse {
-    /// Nonce used to encrypt the wrapped data
-    pub nonce: WrapNonce,
-
-    /// Ciphertext of the encrypted object
-    pub ciphertext: WrappedData,
-}
+pub(crate) struct ExportWrappedResponse(pub(crate) WrapMessage);
 
 impl Response for ExportWrappedResponse {
     const COMMAND_TYPE: CommandType = CommandType::ExportWrapped;

--- a/src/commands/import_wrapped.rs
+++ b/src/commands/import_wrapped.rs
@@ -3,15 +3,20 @@
 //! <https://developers.yubico.com/YubiHSM2/Commands/Import_Wrap_Key.html>
 
 use super::{Command, Response};
-use {CommandType, Connector, ObjectId, ObjectType, Session, SessionError, WrapNonce, WrappedData};
+use {CommandType, Connector, ObjectId, ObjectType, Session, SessionError, WrapMessage, WrapNonce};
 
 /// Import an encrypted object from the `YubiHSM2` using the given key-wrapping key
-pub fn import_wrapped<C: Connector>(
+pub fn import_wrapped<C, M>(
     session: &mut Session<C>,
     wrap_key_id: ObjectId,
-    nonce: WrapNonce,
-    ciphertext: WrappedData,
-) -> Result<ImportWrappedResponse, SessionError> {
+    wrap_message: M,
+) -> Result<ImportWrappedResponse, SessionError>
+where
+    C: Connector,
+    M: Into<WrapMessage>,
+{
+    let WrapMessage { nonce, ciphertext } = wrap_message.into();
+
     session.send_encrypted_command(ImportWrappedCommand {
         wrap_key_id,
         nonce,
@@ -29,7 +34,7 @@ pub(crate) struct ImportWrappedCommand {
     pub nonce: WrapNonce,
 
     /// Ciphertext of the encrypted object
-    pub ciphertext: WrappedData,
+    pub ciphertext: Vec<u8>,
 }
 
 impl Command for ImportWrappedCommand {

--- a/src/commands/list_objects.rs
+++ b/src/commands/list_objects.rs
@@ -2,18 +2,17 @@
 //!
 //! <https://developers.yubico.com/YubiHSM2/Commands/List_Objects.html>
 
-use std::ops::Index;
-use std::slice::Iter;
-
 use super::{Command, Response};
 use {CommandType, Connector, ObjectId, ObjectType, SequenceId, Session, SessionError};
 
 /// List objects visible from the current session
 pub fn list_objects<C: Connector>(
     session: &mut Session<C>,
-) -> Result<ListObjectsResponse, SessionError> {
+) -> Result<Vec<ListObjectsEntry>, SessionError> {
     // TODO: support for filtering objects
-    session.send_encrypted_command(ListObjectsCommand {})
+    session
+        .send_encrypted_command(ListObjectsCommand {})
+        .map(|response| response.0)
 }
 
 /// Request parameters for `commands::list_objects`
@@ -26,45 +25,17 @@ impl Command for ListObjectsCommand {
 
 /// Response from `commands::list_objects`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ListObjectsResponse(pub Vec<ListObjectsEntry>);
+pub(crate) struct ListObjectsResponse(pub(crate) Vec<ListObjectsEntry>);
 
 impl Response for ListObjectsResponse {
     const COMMAND_TYPE: CommandType = CommandType::ListObjects;
-}
-
-impl ListObjectsResponse {
-    /// Number of entries in the response
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Are there no objects in the response?
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Iterate over the objects in the response
-    #[inline]
-    pub fn iter(&self) -> Iter<ListObjectsEntry> {
-        self.0.iter()
-    }
-}
-
-impl Index<usize> for ListObjectsResponse {
-    type Output = ListObjectsEntry;
-
-    fn index(&self, i: usize) -> &ListObjectsEntry {
-        &self.0[i]
-    }
 }
 
 /// Brief information about an object as included in `ListObjectsCommand`
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ListObjectsEntry {
     /// Object identifier
-    pub id: ObjectId,
+    pub object_id: ObjectId,
 
     /// Object type
     pub object_type: ObjectType,

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -5,12 +5,20 @@
 
 use super::{Command, CommandType, Response};
 use connector::Connector;
-use session::Session;
+use session::{Session, SessionError, SessionErrorKind};
 
 /// Reset the `YubiHSM2` to a factory default state and reboot
-pub fn reset<C: Connector>(mut session: Session<C>) {
+pub fn reset<C: Connector>(mut session: Session<C>) -> Result<(), SessionError> {
     // Resetting the session does not send a valid response
-    let _ = session.send_encrypted_command(ResetCommand {});
+    if let Err(e) = session.send_encrypted_command(ResetCommand {}) {
+        match e.kind() {
+            // TODO: we don't handle the yubihsm-connector response to reset correctly
+            SessionErrorKind::ProtocolError => Ok(()),
+            _ => Err(e),
+        }
+    } else {
+        Ok(())
+    }
 }
 
 /// Request parameters for `commands::reset`

--- a/src/commands/unwrap_data.rs
+++ b/src/commands/unwrap_data.rs
@@ -3,20 +3,27 @@
 //! https://developers.yubico.com/YubiHSM2/Commands/Unwrap_Data.html
 
 use super::{Command, Response};
-use {CommandType, Connector, ObjectId, Session, SessionError, WrapNonce, WrappedData};
+use {CommandType, Connector, ObjectId, Session, SessionError, WrapMessage, WrapNonce};
 
 /// Decrypt data which was encrypted (using AES-CCM) under a wrap key
-pub fn unwrap_data<C: Connector>(
+pub fn unwrap_data<C, M>(
     session: &mut Session<C>,
     wrap_key_id: ObjectId,
-    nonce: WrapNonce,
-    ciphertext: WrappedData,
-) -> Result<UnwrapDataResponse, SessionError> {
-    session.send_encrypted_command(UnwrapDataCommand {
-        wrap_key_id,
-        nonce,
-        ciphertext,
-    })
+    wrap_message: M,
+) -> Result<Vec<u8>, SessionError>
+where
+    C: Connector,
+    M: Into<WrapMessage>,
+{
+    let WrapMessage { nonce, ciphertext } = wrap_message.into();
+
+    session
+        .send_encrypted_command(UnwrapDataCommand {
+            wrap_key_id,
+            nonce,
+            ciphertext,
+        })
+        .map(|response| response.0)
 }
 
 /// Request parameters for `commands::unwrap_data`
@@ -29,7 +36,7 @@ pub(crate) struct UnwrapDataCommand {
     pub nonce: WrapNonce,
 
     /// Ciphertext of the encrypted data (including MAC)
-    pub ciphertext: WrappedData,
+    pub ciphertext: Vec<u8>,
 }
 
 impl Command for UnwrapDataCommand {
@@ -38,14 +45,8 @@ impl Command for UnwrapDataCommand {
 
 /// Response from `commands::unwrap_data` containing decrypted plaintext
 #[derive(Serialize, Deserialize, Debug)]
-pub struct UnwrapDataResponse(pub Vec<u8>);
+pub(crate) struct UnwrapDataResponse(pub(crate) Vec<u8>);
 
 impl Response for UnwrapDataResponse {
     const COMMAND_TYPE: CommandType = CommandType::UnwrapData;
-}
-
-impl AsRef<[u8]> for UnwrapDataResponse {
-    fn as_ref(&self) -> &[u8] {
-        &self.0[..]
-    }
 }

--- a/src/mockhsm/objects/mod.rs
+++ b/src/mockhsm/objects/mod.rs
@@ -15,7 +15,7 @@ use auth_key::{AuthKey, AUTH_KEY_DEFAULT_ID, AUTH_KEY_SIZE};
 use serializers::{deserialize, serialize};
 use {
     Algorithm, Capability, Domain, ObjectHandle, ObjectId, ObjectInfo, ObjectLabel, ObjectOrigin,
-    ObjectType, WrapNonce, WrappedData,
+    ObjectType, WrapNonce,
 };
 
 /// Size of the wrap algorithm's MAC tag. The MockHSM uses AES-GCM instead of
@@ -155,7 +155,7 @@ impl Objects {
         object_id: ObjectId,
         object_type: ObjectType,
         nonce: &WrapNonce,
-    ) -> Result<WrappedData, Error> {
+    ) -> Result<Vec<u8>, Error> {
         let wrap_key = match self.get(wrap_key_id, ObjectType::WrapKey) {
             Some(k) => k,
             None => bail!("no such wrap key: {:?}", wrap_key_id),
@@ -209,15 +209,15 @@ impl Objects {
             WRAPPED_DATA_MAC_SIZE,
         ).unwrap();
 
-        Ok(WrappedData(wrapped_object))
+        Ok(wrapped_object)
     }
 
     /// Deserialize an encrypted object and insert it into the HSM
-    pub fn unwrap(
+    pub fn unwrap<V: Into<Vec<u8>>>(
         &mut self,
         wrap_key_id: ObjectId,
         nonce: &WrapNonce,
-        ciphertext: &WrappedData,
+        ciphertext: V,
     ) -> Result<ObjectHandle, Error> {
         let opening_key = match self.get(wrap_key_id, ObjectType::WrapKey) {
             Some(k) => match k.algorithm() {
@@ -228,7 +228,7 @@ impl Objects {
             None => bail!("no such wrap key: {:?}", wrap_key_id),
         };
 
-        let mut wrapped_data = Vec::from(ciphertext.as_ref());
+        let mut wrapped_data: Vec<u8> = ciphertext.into();
 
         if aead::open_in_place(
             &opening_key,

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -56,7 +56,7 @@ macro_rules! session_fail {
 
 impl From<ConnectorError> for SessionError {
     fn from(err: ConnectorError) -> Self {
-        session_err!(ResponseError, err.to_string())
+        session_err!(ProtocolError, err.to_string())
     }
 }
 


### PR DESCRIPTION
Avoids public eposure of various response types, eliminating unnecessary code and making the API simpler and easy to work with.