### PR TITLE
Remove dependency on rand 0.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ring = { version = "0.13", optional = true }
 sha2 = { version = "0.7", optional = true }
 subtle = "0.7"
 untrusted = { version = "0.6", optional = true }
-uuid = { version = "0.6", features = ["v4"] }
+uuid = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/securechannel/command_message.rs
+++ b/src/securechannel/command_message.rs
@@ -9,6 +9,7 @@
 #[cfg(feature = "mockhsm")]
 use byteorder::ByteOrder;
 use byteorder::{BigEndian, WriteBytesExt};
+use rand::{self, RngCore};
 use uuid::Uuid;
 
 use super::{Mac, SecureChannelError, SessionId, MAC_SIZE, MAX_MSG_SIZE};
@@ -51,7 +52,7 @@ impl CommandMessage {
         );
 
         Ok(Self {
-            uuid: Uuid::new_v4(),
+            uuid: uuid_v4(),
             command_type,
             session_id: None,
             data: command_data_vec,
@@ -81,7 +82,7 @@ impl CommandMessage {
         );
 
         Ok(Self {
-            uuid: Uuid::new_v4(),
+            uuid: uuid_v4(),
             command_type,
             session_id: Some(session_id),
             data: command_data_vec,
@@ -144,7 +145,7 @@ impl CommandMessage {
         };
 
         Ok(Self {
-            uuid: Uuid::new_v4(),
+            uuid: uuid_v4(),
             command_type,
             session_id,
             data: bytes,
@@ -187,4 +188,15 @@ impl Into<Vec<u8>> for CommandMessage {
 
         result
     }
+}
+
+/// Create a new random UUIDv4
+// TODO: use `v4` feature of the `uuid` crate when it updates to rand 0.5
+fn uuid_v4() -> Uuid {
+    let mut rng = rand::thread_rng();
+
+    let mut bytes = [0; 16];
+    rng.fill_bytes(&mut bytes);
+
+    Uuid::from_random_bytes(bytes)
 }


### PR DESCRIPTION
The `uuid` crate has not been updated, but we can take care of the random number generation internally and therefore depend only on `rand` 0.5.