### PR TITLE
ObjectType json deserialization helper (u64)

### DIFF
--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -78,6 +78,13 @@ impl<'de> Deserialize<'de> for Type {
             {
                 Type::from_u8(value).or_else(|e| Err(E::custom(format!("{}", e))))
             }
+            fn visit_u64<E>(self, value: u64) -> Result<Type, E>
+            where
+                E: de::Error,
+            {
+                assert!(value < 255);
+                Type::from_u8(value as u8).or_else(|e| Err(E::custom(format!("{}", e))))
+            }
         }
 
         deserializer.deserialize_u8(TypeVisitor)


### PR DESCRIPTION
Json doesn’t preserve integer sizes well. This adds another primitive 
type visitor to allow round-trips of the ObjectType in json.

I was trying to do something like:
```rust
println!("deserialized: {:?}",
         serde_json::from_str::<yubihsm::object::ObjectType>("3")?);
```

and getting
```
error: invalid type: integer `3`, expected an unsigned byte between 0x01 and 0x07 at line 1 column 1
```