### PR TITLE
Handle NUL (i.e. '\0') byte in label before UTF-8 conversion (fixes #81)

### DIFF
--- a/src/mockhsm/objects/mod.rs
+++ b/src/mockhsm/objects/mod.rs
@@ -22,6 +22,9 @@ use {
 /// AES-CCM as there isn't a readily available Rust implementation
 const WRAPPED_DATA_MAC_SIZE: usize = 16;
 
+/// Label for the default auth key
+const DEFAULT_AUTH_KEY_LABEL: &str = "DEFAULT AUTHKEY CHANGE THIS ASAP";
+
 /// Iterator over objects
 pub(crate) type Iter<'a> = HashMapIter<'a, ObjectHandle, Object>;
 
@@ -45,7 +48,7 @@ impl Default for Objects {
             length: AUTH_KEY_SIZE as u16,
             sequence: 1,
             origin: ObjectOrigin::Imported,
-            label: "Default authentication key".into(),
+            label: DEFAULT_AUTH_KEY_LABEL.into(),
         };
 
         let auth_key_payload = Payload::AuthKey(AuthKey::default());

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -26,14 +26,12 @@ impl Label {
 
     /// Create a string representation of this label
     pub fn to_string(&self) -> Result<String, Error> {
-        let mut string = String::from_utf8(self.0.as_ref().into())?;
+        let slice = match self.0.iter().position(|b| *b == b'\0') {
+            Some(pos) => &self.0.as_ref()[..pos],
+            None => self.0.as_ref(),
+        };
 
-        // Ignore trailing zeroes when converting to a String
-        if let Some(pos) = string.find('\0') {
-            string.truncate(pos);
-        }
-
-        Ok(string)
+        Ok(String::from_utf8(slice.into())?)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -34,6 +34,9 @@ const TEST_EXPORTED_KEY_ID: ObjectId = 101;
 /// Label to use for the test key
 const TEST_KEY_LABEL: &str = "yubihsm.rs test key";
 
+/// Label for the default auth key
+const DEFAULT_AUTH_KEY_LABEL: &str = "DEFAULT AUTHKEY CHANGE THIS ASAP";
+
 /// Label to use for the exported test
 const TEST_EXPORTED_KEY_LABEL: &str = "yubihsm.rs exported test key";
 
@@ -327,6 +330,27 @@ fn get_logs_test() {
 
     // TODO: test audit logging functionality
     yubihsm::get_logs(&mut session).unwrap_or_else(|err| panic!("error getting logs: {}", err));
+}
+
+/// Get object info on default auth key
+#[test]
+fn get_object_info_default_authkey() {
+    let mut session = create_session!();
+
+    let object_info =
+        yubihsm::get_object_info(&mut session, AUTH_KEY_DEFAULT_ID, ObjectType::AuthKey)
+            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, Capability::all());
+    assert_eq!(object_info.object_id, AUTH_KEY_DEFAULT_ID);
+    assert_eq!(object_info.domains, Domain::all());
+    assert_eq!(object_info.object_type, ObjectType::AuthKey);
+    assert_eq!(object_info.algorithm, AuthAlgorithm::YUBICO_AES_AUTH.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Imported);
+    assert_eq!(
+        &object_info.label.to_string().unwrap(),
+        DEFAULT_AUTH_KEY_LABEL
+    );
 }
 
 /// Get random bytes


### PR DESCRIPTION
Otherwise it fails converting the default key label

Also adds integration tests that get default auth key info and check the label, including having the MockHSM match the default label.