### PR TITLE
Handle session timeouts

### DIFF
--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -26,6 +26,10 @@ pub enum SessionErrorKind {
     /// HSM returned an error response
     #[fail(display = "bad HSM response")]
     ResponseError,
+
+    /// Session with the YubiHSM2 timed out
+    #[fail(display = "session timeout")]
+    TimeoutError,
 }
 
 /// Create a new Session error with a formatted message
@@ -37,10 +41,7 @@ macro_rules! session_err {
         )
     };
     ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        ::session::SessionError::new(
-            ::session::SessionErrorKind::$kind,
-            Some(format!($fmt, $($arg)+))
-        )
+        session_err!($kind, format!($fmt, $($arg)+))
     };
 }
 


### PR DESCRIPTION
Sessions with the YubiHSM2 are stateful and time out after 30 seconds of inactivity (as tracked by the HSM's internal clock). This manifests as errors from the HSM which are difficult to distinguish from other error conditions.

This commit tracks how long it's been since we've sent a command and returns a `TimeoutError` in the event it's been too long (30 seconds minus 1 second skew).