### PR TITLE
Initial reconnect support

### DIFF
--- a/src/connector/mod.rs
+++ b/src/connector/mod.rs
@@ -21,6 +21,9 @@ pub trait Connector: Sized + Send + Sync {
     /// Open a connection to a yubihsm-connector
     fn open(config: Self::Config) -> Result<Self, ConnectorError>;
 
+    /// Reconnect to yubihsm-connector, closing the existing connection
+    fn reconnect(&self) -> Result<(), ConnectorError>;
+
     /// GET /connector/status returning the result as connector::Status
     fn status(&self) -> Result<Status, ConnectorError>;
 

--- a/src/mockhsm/mod.rs
+++ b/src/mockhsm/mod.rs
@@ -69,6 +69,10 @@ impl Connector for MockConnector {
         panic!("use MockHSM::create_session() to open a MockHSM session");
     }
 
+    fn reconnect(&self) -> Result<(), ConnectorError> {
+        panic!("MockHSM does not support reconnect");
+    }
+
     /// GET /connector/status returning the result as connector::Status
     fn status(&self) -> Result<Status, ConnectorError> {
         Ok(Status {

--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -135,6 +135,12 @@ impl Channel {
         }
     }
 
+    /// Get the channel (i.e. session) ID
+    #[inline]
+    pub fn id(&self) -> Id {
+        self.id
+    }
+
     /// Calculate the card's cryptogram for this session
     pub fn card_cryptogram(&self) -> Cryptogram {
         let mut result_bytes = [0u8; CRYPTOGRAM_SIZE];


### PR DESCRIPTION
Attempt to automatically re-connect to the YubiHSM in the event an error occurs or a connection times out.

Also handles re-opening sockets to yubihsm-connector.

Not tested! Perhaps it works. Perhaps it does not. Testing this seems rather tricky but might be doable to simulate with the MockHSM.