### PR TITLE
Fix idle timeout: track last message time

### DIFF
--- a/src/securechannel/channel.rs
+++ b/src/securechannel/channel.rs
@@ -297,7 +297,15 @@ impl SecureChannel {
             secure_channel_err!(ProtocolError, "no session ID in response")
         })?;
 
-        assert_eq!(self.id, session_id, "session ID mismatch: {:?}", session_id);
+        if self.id != session_id {
+            self.terminate();
+            secure_channel_fail!(
+                SessionMismatch,
+                "message has session ID {} (expected {})",
+                session_id.to_u8(),
+                self.id.to_u8(),
+            );
+        }
 
         let mut mac = Cmac::<Aes128>::new_varkey(self.rmac_key.as_ref()).unwrap();
         mac.input(&self.mac_chaining_value);

--- a/src/securechannel/error.rs
+++ b/src/securechannel/error.rs
@@ -9,10 +9,6 @@ pub type SecureChannelError = Error<SecureChannelErrorKind>;
 /// Secure Channel error kinds
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
 pub enum SecureChannelErrorKind {
-    /// MAC or cryptogram verify failed
-    #[fail(display = "verification failed")]
-    VerifyFailed,
-
     /// Protocol error (i.e. parse error)
     #[fail(display = "protocol error")]
     ProtocolError,
@@ -20,6 +16,14 @@ pub enum SecureChannelErrorKind {
     /// Max commands per session exceeded and a new session should be created
     #[fail(display = "session limit reached")]
     SessionLimitReached,
+
+    /// Message was intended for a different session than the current one
+    #[fail(display = "message has differing session ID")]
+    SessionMismatch,
+
+    /// MAC or cryptogram verify failed
+    #[fail(display = "verification failed")]
+    VerifyFailed,
 }
 
 /// Create a new Secure Channel error with a formatted message


### PR DESCRIPTION
The USB refactoring changes accidentally deleted the code which sets the last command timestamp each time a command is issued. With this broken, it exposed some other bugs in timeout handling, including one which could potentially cause a panic (session ID mismatches).

The timeout handling is now fixed, and session ID mismatches now return an `Error` rather than causing a panic.