### PR TITLE
Unify error handling macros

### DIFF
--- a/src/adapters/error.rs
+++ b/src/adapters/error.rs
@@ -48,41 +48,15 @@ pub enum AdapterErrorKind {
     UsbError,
 }
 
-/// Create a new connector error with a formatted message
-macro_rules! adapter_err {
-    ($kind:ident, $msg:expr) => {
-        ::adapters::AdapterError::new(
-            ::adapters::AdapterErrorKind::$kind,
-            Some($msg.to_owned())
-        )
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        ::adapters::AdapterError::new(
-            ::adapters::AdapterErrorKind::$kind,
-            Some(format!($fmt, $($arg)+))
-        )
-    };
-}
-
-/// Create and return an connector error with a formatted message
-macro_rules! adapter_fail {
-    ($kind:ident, $msg:expr) => {
-        return Err(adapter_err!($kind, $msg).into());
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        return Err(adapter_err!($kind, $fmt, $($arg)+).into());
-    };
-}
-
 impl From<fmt::Error> for AdapterError {
     fn from(err: fmt::Error) -> Self {
-        adapter_err!(IoError, err.to_string())
+        err!(AdapterErrorKind::IoError, err.to_string())
     }
 }
 
 impl From<io::Error> for AdapterError {
     fn from(err: io::Error) -> Self {
-        adapter_err!(IoError, err.to_string())
+        err!(AdapterErrorKind::IoError, err.to_string())
     }
 }
 
@@ -90,21 +64,21 @@ impl From<io::Error> for AdapterError {
 impl From<libusb::Error> for AdapterError {
     fn from(err: libusb::Error) -> AdapterError {
         match err {
-            libusb::Error::Access => adapter_err!(AccessDenied, "{}", err),
-            libusb::Error::Io => adapter_err!(IoError, "{}", err),
-            _ => adapter_err!(UsbError, "{}", err),
+            libusb::Error::Access => err!(AdapterErrorKind::AccessDenied, "{}", err),
+            libusb::Error::Io => err!(AdapterErrorKind::IoError, "{}", err),
+            _ => err!(AdapterErrorKind::UsbError, "{}", err),
         }
     }
 }
 
 impl From<ParseIntError> for AdapterError {
     fn from(err: ParseIntError) -> Self {
-        adapter_err!(ResponseError, err.to_string())
+        err!(AdapterErrorKind::ResponseError, err.to_string())
     }
 }
 
 impl From<Utf8Error> for AdapterError {
     fn from(err: Utf8Error) -> Self {
-        adapter_err!(ResponseError, err.to_string())
+        err!(AdapterErrorKind::ResponseError, err.to_string())
     }
 }

--- a/src/adapters/http/adapter.rs
+++ b/src/adapters/http/adapter.rs
@@ -9,7 +9,7 @@ use std::{
 use uuid::Uuid;
 
 use super::{ConnectorStatus, HttpConfig, ResponseReader, USER_AGENT};
-use adapters::{Adapter, AdapterError};
+use adapters::{Adapter, AdapterError, AdapterErrorKind::AddrInvalid};
 
 /// HTTP(-ish) adapter which supports the minimal parts of the protocol
 /// required to communicate with the yubihsm-connector service.
@@ -32,7 +32,7 @@ impl Adapter for HttpAdapter {
         // Resolve DNS, and for now pick the first available address
         // TODO: round robin DNS support?
         let socketaddr = &host.to_socket_addrs()?.next().ok_or_else(|| {
-            adapter_err!(
+            err!(
                 AddrInvalid,
                 "couldn't resolve DNS for {}",
                 host.split(':').next().unwrap()

--- a/src/adapters/usb/adapter.rs
+++ b/src/adapters/usb/adapter.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use super::{UsbConfig, UsbDevices, UsbTimeout};
-use adapters::{Adapter, AdapterError};
+use adapters::{Adapter, AdapterError, AdapterErrorKind::UsbError};
 use securechannel::MAX_MSG_SIZE;
 use serial::SerialNumber;
 use uuid::Uuid;
@@ -132,7 +132,7 @@ fn send_message(
     if data.len() == nbytes {
         Ok(nbytes)
     } else {
-        adapter_fail!(
+        fail!(
             UsbError,
             "incomplete bulk transfer: {} of {} bytes",
             nbytes,

--- a/src/algorithm/error.rs
+++ b/src/algorithm/error.rs
@@ -1,0 +1,14 @@
+//! `Algorithm`-related errors
+
+use error::Error;
+
+/// `Algorithm`-related errors
+pub type AlgorithmError = Error<AlgorithmErrorKind>;
+
+/// Kinds of `Algorithm`-related errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum AlgorithmErrorKind {
+    /// Size is invalid
+    #[fail(display = "invalid size")]
+    SizeInvalid,
+}

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -30,6 +30,9 @@ macro_rules! impl_algorithm {
     };
 }
 
+mod error;
+pub use self::error::{AlgorithmError, AlgorithmErrorKind};
+
 mod asymmetric_algorithm;
 mod auth_algorithm;
 mod hmac_algorithm;
@@ -37,12 +40,10 @@ mod opaque_algorithm;
 mod otp_algorithm;
 mod wrap_algorithm;
 
-pub use self::asymmetric_algorithm::*;
-pub use self::auth_algorithm::*;
-pub use self::hmac_algorithm::*;
-pub use self::opaque_algorithm::*;
-pub use self::otp_algorithm::*;
-pub use self::wrap_algorithm::*;
+pub use self::{
+    asymmetric_algorithm::*, auth_algorithm::*, hmac_algorithm::*, opaque_algorithm::*,
+    otp_algorithm::*, wrap_algorithm::*,
+};
 
 /// Cryptographic algorithm types supported by the `YubiHSM2`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/algorithm/wrap_algorithm.rs
+++ b/src/algorithm/wrap_algorithm.rs
@@ -3,7 +3,7 @@ use failure::Error;
 use rand::{OsRng, RngCore};
 use std::fmt;
 
-use super::Algorithm;
+use super::{Algorithm, AlgorithmError, AlgorithmErrorKind::SizeInvalid};
 
 /// Valid algorithms for "wrap" (symmetric encryption/key wrapping) keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -55,9 +55,10 @@ pub struct WrapMessage {
 
 impl WrapMessage {
     /// Load a `WrapMessage` from a byte vector
-    pub fn from_vec(mut vec: Vec<u8>) -> Result<Self, Error> {
+    pub fn from_vec(mut vec: Vec<u8>) -> Result<Self, AlgorithmError> {
         ensure!(
             vec.len() >= WRAP_NONCE_SIZE,
+            SizeInvalid,
             "message must be at least {}-bytes",
             WRAP_NONCE_SIZE
         );

--- a/src/auth_key.rs
+++ b/src/auth_key.rs
@@ -1,7 +1,7 @@
 //! `YubiHSM2` authentication keys (2 * AES-128 symmetric PSK) from which session keys are derived
 
 use clear_on_drop::clear::Clear;
-use failure::Error;
+use error::Error;
 #[cfg(feature = "hmac")]
 use hmac::Hmac;
 #[cfg(feature = "pbkdf2")]
@@ -58,9 +58,10 @@ impl AuthKey {
 
     /// Create an AuthKey from a 32-byte slice, returning an error if the key
     /// is the wrong length
-    pub fn from_slice(key_slice: &[u8]) -> Result<Self, Error> {
+    pub fn from_slice(key_slice: &[u8]) -> Result<Self, AuthKeyError> {
         ensure!(
             key_slice.len() == AUTH_KEY_SIZE,
+            AuthKeyErrorKind::SizeInvalid,
             "expected {}-byte key, got {}",
             AUTH_KEY_SIZE,
             key_slice.len()
@@ -121,3 +122,14 @@ impl From<[u8; AUTH_KEY_SIZE]> for AuthKey {
 }
 
 impl_array_serializers!(AuthKey, AUTH_KEY_SIZE);
+
+/// `AuthKey`-related errors
+pub type AuthKeyError = Error<AuthKeyErrorKind>;
+
+/// Kinds of `AuthKey`-related errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum AuthKeyErrorKind {
+    /// Size is invalid
+    #[fail(display = "invalid size")]
+    SizeInvalid,
+}

--- a/src/commands/create_session.rs
+++ b/src/commands/create_session.rs
@@ -5,7 +5,7 @@
 use super::{Command, Response};
 use securechannel::{Challenge, CommandMessage, Cryptogram, ResponseMessage};
 use serializers::deserialize;
-use session::SessionError;
+use session::{SessionError, SessionErrorKind::*};
 use {Adapter, CommandType, ObjectId, SessionId};
 
 /// Create a new encrypted session with the YubiHSM2 using the given connector
@@ -24,11 +24,11 @@ pub(crate) fn create_session<A: Adapter>(
     let response_message = ResponseMessage::parse(response_body)?;
 
     if response_message.is_err() {
-        command_fail!(ResponseError, "HSM error: {:?}", response_message.code);
+        fail!(ResponseError, "HSM error: {:?}", response_message.code);
     }
 
     if response_message.command().unwrap() != CommandType::CreateSession {
-        command_fail!(
+        fail!(
             ProtocolError,
             "command type mismatch: expected {:?}, got {:?}",
             CommandType::CreateSession,
@@ -38,7 +38,7 @@ pub(crate) fn create_session<A: Adapter>(
 
     let session_id = response_message
         .session_id
-        .ok_or_else(|| command_err!(CreateFailed, "no session ID in response"))?;
+        .ok_or_else(|| err!(CreateFailed, "no session ID in response"))?;
 
     let session_response = deserialize(response_message.data.as_ref())?;
 

--- a/src/commands/get_pseudo_random.rs
+++ b/src/commands/get_pseudo_random.rs
@@ -3,6 +3,7 @@
 //! <https://developers.yubico.com/YubiHSM2/Commands/Get_Pseudo_Random.html>
 //!
 use super::{Command, Response};
+use session::SessionErrorKind::ProtocolError;
 use {Adapter, CommandType, Session, SessionError};
 
 pub(crate) const MAX_RAND_BYTES: u16 = 2048 // packet size
@@ -15,7 +16,7 @@ pub fn get_pseudo_random<A: Adapter>(
     bytes: u16,
 ) -> Result<Vec<u8>, SessionError> {
     if bytes >= MAX_RAND_BYTES {
-        command_fail!(
+        fail!(
             ProtocolError,
             "Requested too many random bytes (>= 2045) to fit in response packet"
         );

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,32 +8,6 @@ use securechannel::CommandMessage;
 use securechannel::ResponseMessage;
 use serializers::serialize;
 
-/// Create a command error (presently just a `SessionError`)
-macro_rules! command_err {
-    ($kind:ident, $msg:expr) => {
-        ::session::SessionError::new(
-            ::session::SessionErrorKind::$kind,
-            Some($msg.to_owned())
-        )
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        ::session::SessionError::new(
-            ::session::SessionErrorKind::$kind,
-            Some(format!($fmt, $($arg)+))
-        )
-    };
-}
-
-/// Create and return a command error (presently just a `SessionError`)
-macro_rules! command_fail {
-    ($kind:ident, $msg:expr) => {
-        return Err(command_err!($kind, $msg).into());
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        return Err(command_err!($kind, $fmt, $($arg)+).into());
-    };
-}
-
 pub mod attest_asymmetric;
 pub mod blink;
 pub(crate) mod close_session;

--- a/src/commands/put_asymmetric_key.rs
+++ b/src/commands/put_asymmetric_key.rs
@@ -4,6 +4,7 @@
 
 use super::put_object::PutObjectParams;
 use super::{Command, Response};
+use session::SessionErrorKind::ProtocolError;
 use {
     Adapter, AsymmetricAlgorithm, Capability, CommandType, Domain, ObjectId, ObjectLabel, Session,
     SessionError,
@@ -22,7 +23,7 @@ pub fn put_asymmetric_key<A: Adapter, T: Into<Vec<u8>>>(
     let data = key_bytes.into();
 
     if data.len() != algorithm.key_len() {
-        command_fail!(
+        fail!(
             ProtocolError,
             "invalid key length for {:?}: {} (expected {})",
             algorithm,

--- a/src/commands/put_hmac_key.rs
+++ b/src/commands/put_hmac_key.rs
@@ -4,6 +4,7 @@
 
 use super::put_object::PutObjectParams;
 use super::{Command, Response};
+use session::SessionErrorKind::ProtocolError;
 use {
     Adapter, Capability, CommandType, Domain, HMACAlgorithm, ObjectId, ObjectLabel, Session,
     SessionError,
@@ -25,7 +26,7 @@ pub fn put_hmac_key<A: Adapter, T: Into<Vec<u8>>>(
     let hmac_key = key_bytes.into();
 
     if hmac_key.len() < HMAC_MIN_KEY_SIZE || hmac_key.len() > algorithm.max_key_len() {
-        command_fail!(
+        fail!(
             ProtocolError,
             "invalid key length for {:?}: {} (min {}, max {})",
             algorithm,

--- a/src/commands/put_otp_aead_key.rs
+++ b/src/commands/put_otp_aead_key.rs
@@ -4,6 +4,7 @@
 
 use super::put_object::PutObjectParams;
 use super::{Command, Response};
+use session::SessionErrorKind::ProtocolError;
 use {
     Adapter, Capability, CommandType, Domain, OTPAlgorithm, ObjectId, ObjectLabel, Session,
     SessionError,
@@ -24,7 +25,7 @@ pub fn put_otp_aead_key<A: Adapter, T: Into<Vec<u8>>>(
     let data = key_bytes.into();
 
     if data.len() != algorithm.key_len() {
-        command_fail!(
+        fail!(
             ProtocolError,
             "invalid key length for {:?}: {} (expected {})",
             algorithm,

--- a/src/commands/put_wrap_key.rs
+++ b/src/commands/put_wrap_key.rs
@@ -4,6 +4,7 @@
 
 use super::put_object::PutObjectParams;
 use super::{Command, Response};
+use session::SessionErrorKind::ProtocolError;
 use {
     Adapter, Capability, CommandType, Domain, ObjectId, ObjectLabel, Session, SessionError,
     WrapAlgorithm,
@@ -24,7 +25,7 @@ pub fn put_wrap_key<A: Adapter, T: Into<Vec<u8>>>(
     let data = key_bytes.into();
 
     if data.len() != algorithm.key_len() {
-        command_fail!(
+        fail!(
             ProtocolError,
             "invalid key length for {:?}: {} (expected {})",
             algorithm,

--- a/src/commands/sign_rsa_pss.rs
+++ b/src/commands/sign_rsa_pss.rs
@@ -5,7 +5,7 @@
 use byteorder::{BigEndian, ByteOrder};
 
 use super::{Command, Response};
-use session::{Session, SessionError};
+use session::{Session, SessionError, SessionErrorKind::ProtocolError};
 use sha2::{Digest, Sha256};
 use Adapter;
 use {Algorithm, CommandType, ObjectId};
@@ -23,7 +23,7 @@ pub fn sign_rsa_pss_sha256<A: Adapter>(
     data: &[u8],
 ) -> Result<RSAPSSSignature, SessionError> {
     if data.len() > RSA_PSS_MAX_MESSAGE_SIZE {
-        command_fail!(
+        fail!(
             ProtocolError,
             "message too large to be signed (max: {})",
             RSA_PSS_MAX_MESSAGE_SIZE

--- a/src/commands/verify_hmac.rs
+++ b/src/commands/verify_hmac.rs
@@ -4,6 +4,7 @@
 
 use super::hmac::HMACTag;
 use super::{Command, Response};
+use session::SessionErrorKind::ResponseError;
 use {Adapter, CommandType, ObjectId, Session, SessionError};
 
 /// Verify an HMAC tag of the given data with the given key ID
@@ -27,7 +28,7 @@ where
     if result.0 == 1 {
         Ok(())
     } else {
-        Err(command_err!(ResponseError, "HMAC verification failure"))
+        Err(err!(ResponseError, "HMAC verification failure"))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,3 +54,37 @@ where
         }
     }
 }
+
+/// Create a new error (of a given kind) with a formatted message
+macro_rules! err {
+    ($kind:path, $msg:expr) => {
+        ::error::Error::new($kind, Some($msg.to_string()))
+    };
+    ($kind:path, $fmt:expr, $($arg:tt)+) => {
+        err!($kind, &format!($fmt, $($arg)+))
+    };
+}
+
+/// Create and return an error with a formatted message
+macro_rules! fail {
+    ($kind:path, $msg:expr) => {
+        return Err(err!($kind, $msg).into());
+    };
+    ($kind:path, $fmt:expr, $($arg:tt)+) => {
+        fail!($kind, &format!($fmt, $($arg)+));
+    };
+}
+
+/// Assert a condition is true, returning an error type with a formatted message if not
+macro_rules! ensure {
+    ($cond:expr, $kind:path, $msg:expr) => {
+        if !($cond) {
+            return Err(err!($kind, $msg).into());
+        }
+    };
+    ($cond:expr, $kind:path, $fmt:expr, $($arg:tt)+) => {
+        if !($cond) {
+            return Err(err!($kind, $fmt, $($arg)+).into());
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ extern crate untrusted;
 extern crate uuid;
 
 /// Error types
+#[macro_use]
 pub mod error;
 
 /// Serde-powered serializers for the `YubiHSM2` wire format

--- a/src/securechannel/error.rs
+++ b/src/securechannel/error.rs
@@ -26,48 +26,8 @@ pub enum SecureChannelErrorKind {
     VerifyFailed,
 }
 
-/// Create a new Secure Channel error with a formatted message
-macro_rules! secure_channel_err {
-    ($kind:ident, $msg:expr) => {
-        ::securechannel::SecureChannelError::new(
-            ::securechannel::SecureChannelErrorKind::$kind,
-            Some($msg.to_owned())
-        )
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        ::securechannel::SecureChannelError::new(
-            ::securechannel::SecureChannelErrorKind::$kind,
-            Some(format!($fmt, $($arg)+))
-        )
-    };
-}
-
-/// Create and return a Secure Channel error with a formatted message
-macro_rules! secure_channel_fail {
-    ($kind:ident, $msg:expr) => {
-        return Err(secure_channel_err!($kind, $msg).into());
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        return Err(secure_channel_err!($kind, $fmt, $($arg)+).into());
-    };
-}
-
-/// Assert a condition is true, returning an error type with a formatted message if not
-macro_rules! secure_channel_ensure {
-    ($condition:expr, $kind:ident, $msg:expr) => {
-        if !($condition) {
-            secure_channel_fail!($kind, $msg);
-        }
-    };
-    ($condition:expr, $kind:ident, $fmt:expr, $($arg:tt)+) => {
-        if !($condition) {
-            secure_channel_fail!($kind, $fmt, $($arg)+);
-        }
-    };
-}
-
 impl From<AdapterError> for SecureChannelError {
     fn from(err: AdapterError) -> Self {
-        secure_channel_err!(ProtocolError, err.to_string())
+        err!(SecureChannelErrorKind::ProtocolError, err.to_string())
     }
 }

--- a/src/securechannel/mac.rs
+++ b/src/securechannel/mac.rs
@@ -12,7 +12,7 @@ use cmac::crypto_mac::generic_array::GenericArray;
 use std::fmt;
 use subtle::{Choice, ConstantTimeEq};
 
-use super::SecureChannelError;
+use super::{SecureChannelError, SecureChannelErrorKind::VerifyFailed};
 
 /// Size of the MAC in bytes: SCP03 truncates it to 8-bytes
 pub const MAC_SIZE: usize = 8;
@@ -45,7 +45,7 @@ impl Mac {
         if self.ct_eq(&other.into()).unwrap_u8() == 1 {
             Ok(())
         } else {
-            secure_channel_fail!(VerifyFailed, "MAC mismatch!");
+            fail!(VerifyFailed, "MAC mismatch!");
         }
     }
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,18 +1,9 @@
 use std::str;
 
-use adapters::{AdapterError, AdapterErrorKind};
+use adapters::{AdapterError, AdapterErrorKind::AddrInvalid};
 
 /// Length of a YubiHSM2 serial number
 pub const SERIAL_SIZE: usize = 10;
-
-macro_rules! err {
-    ($msg:expr) => {
-        AdapterError::new(AdapterErrorKind::AddrInvalid, Some($msg.to_owned()))
-    };
-    ($fmt:expr, $($arg:tt)+) => {
-        err!(format!($fmt, $($arg)+))
-    };
-}
 
 /// YubiHSM serial numbers
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
@@ -34,15 +25,26 @@ impl AsRef<str> for SerialNumber {
 impl str::FromStr for SerialNumber {
     type Err = AdapterError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<SerialNumber, AdapterError> {
         if s.len() != SERIAL_SIZE {
-            return Err(err!("invalid serial number length ({}): {}", s.len(), s));
+            return Err(err!(
+                AddrInvalid,
+                "invalid serial number length ({}): {}",
+                s.len(),
+                s
+            ));
         }
 
         for char in s.chars() {
             match char {
                 '0'...'9' => (),
-                _ => return Err(err!("invalid character in serial number: {}", s)),
+                _ => {
+                    return Err(err!(
+                        AddrInvalid,
+                        "invalid character in serial number: {}",
+                        s
+                    ))
+                }
             }
         }
 

--- a/src/serializers/error.rs
+++ b/src/serializers/error.rs
@@ -22,36 +22,20 @@ pub enum SerializationErrorKind {
     UnexpectedEof,
 }
 
-/// Create a new serialization error with a formatted message
-macro_rules! serialization_err {
-    ($kind:ident, $msg:expr) => {
-        SerializationError::new(
-            ::serializers::SerializationErrorKind::$kind,
-            Some($msg.to_owned())
-        )
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        SerializationError::new(
-            ::serializers::SerializationErrorKind::$kind,
-            Some(format!($fmt, $($arg)+))
-        )
-    };
-}
-
 impl serde::ser::Error for SerializationError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        serialization_err!(Parse, msg.to_string())
+        err!(SerializationErrorKind::Parse, msg.to_string())
     }
 }
 
 impl serde::de::Error for SerializationError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        serialization_err!(Parse, msg.to_string())
+        err!(SerializationErrorKind::Parse, msg.to_string())
     }
 }
 
 impl From<io::Error> for SerializationError {
     fn from(err: io::Error) -> Self {
-        serialization_err!(Io, err.to_string())
+        err!(SerializationErrorKind::Io, err.to_string())
     }
 }

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -36,43 +36,20 @@ pub enum SessionErrorKind {
     TimeoutError,
 }
 
-/// Create a new Session error with a formatted message
-macro_rules! session_err {
-    ($kind:ident, $msg:expr) => {
-        ::session::SessionError::new(
-            ::session::SessionErrorKind::$kind,
-            Some($msg.to_owned())
-        )
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        session_err!($kind, format!($fmt, $($arg)+))
-    };
-}
-
-/// Create and return a Session error with a formatted message
-macro_rules! session_fail {
-    ($kind:ident, $msg:expr) => {
-        return Err(session_err!($kind, $msg).into());
-    };
-    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
-        return Err(session_err!($kind, $fmt, $($arg)+).into());
-    };
-}
-
 impl From<AdapterError> for SessionError {
     fn from(err: AdapterError) -> Self {
-        session_err!(ProtocolError, err.to_string())
+        err!(SessionErrorKind::ProtocolError, err.to_string())
     }
 }
 
 impl From<SecureChannelError> for SessionError {
     fn from(err: SecureChannelError) -> Self {
-        session_err!(ProtocolError, err.to_string())
+        err!(SessionErrorKind::ProtocolError, err.to_string())
     }
 }
 
 impl From<SerializationError> for SessionError {
     fn from(err: SerializationError) -> Self {
-        session_err!(ProtocolError, err.to_string())
+        err!(SessionErrorKind::ProtocolError, err.to_string())
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod connection;
 mod timeout;
 
 use self::connection::Connection;
+use self::error::SessionErrorKind::*;
 pub use self::{
     error::{SessionError, SessionErrorKind},
     timeout::SessionTimeout,
@@ -110,7 +111,7 @@ impl<A: Adapter> Session<A> {
         self.connection.open(
             self.credentials
                 .as_ref()
-                .ok_or_else(|| session_err!(AuthFailed, "session reconnection disabled"))?,
+                .ok_or_else(|| err!(AuthFailed, "session reconnection disabled"))?,
         )?;
 
         self.last_command_timestamp = Instant::now();
@@ -207,11 +208,11 @@ impl<A: Adapter> Session<A> {
                 &description
             );
 
-            session_fail!(ResponseError, description);
+            fail!(ResponseError, description);
         }
 
         if response.command().unwrap() != T::COMMAND_TYPE {
-            session_fail!(
+            fail!(
                 ResponseError,
                 "command type mismatch: expected {:?}, got {:?}",
                 T::COMMAND_TYPE,


### PR DESCRIPTION
Cleans up the diaspora of `ErrorKind`-specific error macros by having a simpler macro and leaning on Rust's module system to handle all of the different enums/variants.