### PR TITLE
Refactor session::Connection

### DIFF
--- a/src/mockhsm/adapter.rs
+++ b/src/mockhsm/adapter.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
-use super::{commands, state::State, MockConfig};
+use super::{commands, state::State, MockHSM};
 use adapters::{Adapter, AdapterError, AdapterErrorKind::ConnectionFailed};
 use commands::CommandType;
 use securechannel::CommandMessage;
@@ -9,19 +9,12 @@ use securechannel::CommandMessage;
 /// A mocked connection to the MockHSM
 pub struct MockAdapter(Arc<Mutex<State>>);
 
-impl MockAdapter {
-    pub(super) fn new(state: Arc<Mutex<State>>) -> Self {
-        MockAdapter(state)
-    }
-}
-
 impl Adapter for MockAdapter {
-    type Config = MockConfig;
+    type Config = MockHSM;
 
-    /// We don't bother to implement this
-    // TODO: use this as the entry point for the `MockHSM`'s `Arc<Mutex<State>>`?
-    fn open(_config: &MockConfig) -> Result<Self, AdapterError> {
-        panic!("unimplemented");
+    /// Create a new adapter with a clone of the MockHSM state
+    fn open(hsm: &MockHSM) -> Result<Self, AdapterError> {
+        Ok(MockAdapter(hsm.0.clone()))
     }
 
     /// Rust never sleeps

--- a/src/mockhsm/objects/ecdsa.rs
+++ b/src/mockhsm/objects/ecdsa.rs
@@ -1,6 +1,7 @@
 //! ECDSA keypairs
 
 use ring::rand::{SecureRandom, SystemRandom};
+use std::fmt::{self, Debug};
 
 // TODO: ideally *ring* could do everything our `ECDSAKeyPair` type is doing.
 // This is the biggest blocker: https://github.com/briansmith/ring/issues/672
@@ -70,5 +71,11 @@ impl ECDSAKeyPair {
                 untrusted::Input::from(message.as_ref()),
                 &SystemRandom::new(),
             ).unwrap()
+    }
+}
+
+impl Debug for ECDSAKeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ECDSAKeyPair {{ alg: {:?} }}", self.algorithm)
     }
 }

--- a/src/mockhsm/objects/mod.rs
+++ b/src/mockhsm/objects/mod.rs
@@ -30,6 +30,7 @@ const DEFAULT_AUTH_KEY_LABEL: &str = "DEFAULT AUTHKEY CHANGE THIS ASAP";
 pub(crate) type Iter<'a> = HashMapIter<'a, ObjectHandle, Object>;
 
 /// Objects stored in the `MockHSM`
+#[derive(Debug)]
 pub(crate) struct Objects(HashMap<ObjectHandle, Object>);
 
 impl Default for Objects {
@@ -279,6 +280,7 @@ impl Objects {
 }
 
 /// An individual object in the `MockHSM`, specialized for a given object type
+#[derive(Debug)]
 pub(crate) struct Object {
     pub object_info: ObjectInfo,
     pub payload: Payload,

--- a/src/mockhsm/objects/payload.rs
+++ b/src/mockhsm/objects/payload.rs
@@ -13,6 +13,7 @@ use auth_key::{AuthKey, AUTH_KEY_SIZE};
 pub(crate) const ED25519_SEED_SIZE: usize = 32;
 
 /// Loaded instances of a cryptographic primitives in the MockHSM
+#[derive(Debug)]
 pub(crate) enum Payload {
     /// Authentication keys
     AuthKey(AuthKey),

--- a/src/mockhsm/session.rs
+++ b/src/mockhsm/session.rs
@@ -1,5 +1,7 @@
 //! Sessions with the `MockHSM`
 
+use std::fmt::{self, Debug};
+
 use securechannel::{Challenge, CommandMessage, Cryptogram, ResponseMessage, SecureChannel};
 use SessionId;
 
@@ -43,5 +45,11 @@ impl Session {
     /// Encrypt an outgoing response
     pub fn encrypt_response(&mut self, response: ResponseMessage) -> ResponseMessage {
         self.channel.encrypt_response(response).unwrap()
+    }
+}
+
+impl Debug for Session {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "mockhsm::Session {{ id: {} }}", self.id.to_u8())
     }
 }

--- a/src/mockhsm/state.rs
+++ b/src/mockhsm/state.rs
@@ -11,6 +11,7 @@ use super::objects::Objects;
 use super::session::Session;
 
 /// Mutable interior state of the `MockHSM`
+#[derive(Debug)]
 pub(crate) struct State {
     sessions: BTreeMap<SessionId, Session>,
     pub objects: Objects,

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -1,6 +1,8 @@
 use failure::Error;
-use serde::de::{self, Deserialize, Deserializer, Visitor};
-use serde::ser::{Serialize, Serializer};
+use serde::{
+    de::{self, Deserialize, Deserializer, Visitor},
+    ser::{Serialize, Serializer},
+};
 use std::fmt;
 
 /// Types of objects

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -92,7 +92,7 @@ macro_rules! create_session {
 #[cfg(feature = "mockhsm")]
 macro_rules! create_session {
     () => {
-        MockHSM::new().create_session(DEFAULT_AUTH_KEY_ID, AuthKey::default())
+        TestSession::create(MockHSM::new(), Default::default(), true).unwrap()
     };
 }
 


### PR DESCRIPTION
This type is now one-shot, with `Session` handling all reconnection logic.

Additionally MockHSM now better implements the Adapter API.