### PR TITLE
Implement Put Option commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ or open an issue requesting support.
 | [Put Auth Key]         | ✅     | ✅        | Put AES-128x2 preshared authentication key into HSM |
 | [Put HMAC Key]         | ✅     | ✅        | Put an HMAC key into the HSM |
 | [Put Opaque]           | ✅     | ✅        | Put an opaque bytestring into the HSM |
-| [Put Option]           | ⛔     | ⛔        | Change HSM auditing settings |
+| [Put Option]           | ✅     | ✅        | Change HSM auditing settings |
 | [Put OTP AEAD Key]     | ✅     | ⛔        | Put a Yubico OTP key into the HSM |
 | [Put Wrap Key]         | ✅     | ✅        | Put an AES keywrapping key into the HSM |
 | [Reset]                | ✅     | ✅        | Reset the HSM back to factory default settings |
@@ -131,7 +131,7 @@ or open an issue requesting support.
 [Get Logs]: https://docs.rs/yubihsm/latest/yubihsm/commands/get_logs/fn.get_logs.html
 [Get Object Info]: https://docs.rs/yubihsm/latest/yubihsm/commands/get_object_info/fn.get_object_info.html
 [Get Opaque]: https://docs.rs/yubihsm/latest/yubihsm/commands/get_opaque/fn.get_opaque.html
-[Get Option]: https://developers.yubico.com/YubiHSM2/Commands/Get_Option.html
+[Get Option]: https://docs.rs/yubihsm/latest/yubihsm/commands/get_option/
 [Get Pseudo Random]: https://docs.rs/yubihsm/latest/yubihsm/commands/get_pseudo_random/fn.get_pseudo_random.html
 [Get Pubkey]: https://docs.rs/yubihsm/latest/yubihsm/commands/get_pubkey/fn.get_pubkey.html
 [HMAC Data]: https://docs.rs/yubihsm/latest/yubihsm/commands/hmac/fn.hmac.html

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -7,12 +7,18 @@ use commands::CommandType;
 
 /// Audit settings for a particular command
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct AuditCommand {
-    /// Command being audited
-    pub command: CommandType,
+pub struct AuditCommand(pub CommandType, pub AuditOption);
 
-    /// Audit settings for this command
-    pub audit: AuditOption,
+impl AuditCommand {
+    /// Get the command type
+    pub fn command_type(&self) -> CommandType {
+        self.0
+    }
+
+    /// Get the audit option
+    pub fn audit_option(&self) -> AuditOption {
+        self.1
+    }
 }
 
 /// Auditing policy options

--- a/src/commands/get_logs.rs
+++ b/src/commands/get_logs.rs
@@ -9,7 +9,7 @@ use securechannel::ResponseCode;
 use {Adapter, CommandType, ObjectId, Session, SessionError};
 
 /// Get audit logs from the YubiHSM2 device
-pub fn get_logs<A: Adapter>(session: &mut Session<A>) -> Result<GetLogsResponse, SessionError> {
+pub fn get_audit_logs<A: Adapter>(session: &mut Session<A>) -> Result<AuditLogs, SessionError> {
     session.send_command(GetLogsCommand {})
 }
 
@@ -18,12 +18,12 @@ pub fn get_logs<A: Adapter>(session: &mut Session<A>) -> Result<GetLogsResponse,
 pub(crate) struct GetLogsCommand {}
 
 impl Command for GetLogsCommand {
-    type ResponseType = GetLogsResponse;
+    type ResponseType = AuditLogs;
 }
 
 /// Response from `commands::get_logs`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct GetLogsResponse {
+pub struct AuditLogs {
     /// Number of boot events which weren't logged (if buffer is full and audit enforce is set)
     pub unlogged_boot_events: u16,
 
@@ -37,7 +37,7 @@ pub struct GetLogsResponse {
     pub entries: Vec<LogEntry>,
 }
 
-impl Response for GetLogsResponse {
+impl Response for AuditLogs {
     const COMMAND_TYPE: CommandType = CommandType::GetLogs;
 }
 

--- a/src/commands/get_option.rs
+++ b/src/commands/get_option.rs
@@ -12,12 +12,13 @@ use {Adapter, CommandType};
 pub fn get_command_audit_option<A: Adapter>(
     session: &mut Session<A>,
     command: CommandType,
-) -> Result<Option<AuditOption>, SessionError> {
+) -> Result<AuditOption, SessionError> {
     let command_audit_options = get_all_command_audit_options(session)?;
     Ok(command_audit_options
         .iter()
-        .find(|opt| opt.command == command)
-        .map(|opt| opt.audit))
+        .find(|opt| opt.command_type() == command)
+        .map(|opt| opt.audit_option())
+        .unwrap_or(AuditOption::Off))
 }
 
 /// Get the audit policy settings for all commands

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,6 +34,7 @@ pub mod put_auth_key;
 pub mod put_hmac_key;
 mod put_object;
 pub mod put_opaque;
+pub mod put_option;
 pub mod put_otp_aead_key;
 pub mod put_wrap_key;
 pub mod reset;
@@ -80,7 +81,7 @@ pub(crate) trait Response: Serialize + DeserializeOwned + Sized {
 }
 
 /// Command IDs for `YubiHSM2` operations
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[allow(missing_docs)]
 #[repr(u8)]
 pub enum CommandType {

--- a/src/commands/put_option.rs
+++ b/src/commands/put_option.rs
@@ -1,0 +1,72 @@
+//! Put auditing options which have been configured on the device.
+//!
+//! <https://developers.yubico.com/YubiHSM2/Commands/Put_Option.html>
+
+use super::{Command, Response};
+use audit::*;
+use serializers::serialize;
+use session::{Session, SessionError};
+use {Adapter, CommandType};
+
+/// Configure the audit policy settings for a particular command, e.g. auditing
+/// should be `On`, `Off`, or `Fix` (i.e. fixed permanently on)
+pub fn put_command_audit_option<A>(
+    session: &mut Session<A>,
+    command: CommandType,
+    audit_option: AuditOption,
+) -> Result<(), SessionError>
+where
+    A: Adapter,
+{
+    session.send_command(PutOptionCommand {
+        tag: AuditTag::Command,
+        length: 2,
+        value: serialize(&AuditCommand(command, audit_option))?,
+    })?;
+
+    Ok(())
+}
+
+/// Put the forced auditing global option: when enabled, the device will
+/// refuse operations if the [log store] becomes full.
+///
+/// Options are `On`, `Off`, or `Fix` (i.e. fixed permanently on)
+///
+/// [log store]: https://developers.yubico.com/YubiHSM2/Concepts/Logs.html
+pub fn put_force_audit_option<A: Adapter>(
+    session: &mut Session<A>,
+    option: AuditOption,
+) -> Result<(), SessionError> {
+    session.send_command(PutOptionCommand {
+        tag: AuditTag::Force,
+        length: 1,
+        value: vec![option.to_u8()],
+    })?;
+
+    Ok(())
+}
+
+/// Request parameters for `commands::put_option`
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct PutOptionCommand {
+    /// Tag byte for `Force` vs `Command` options
+    pub tag: AuditTag,
+
+    /// Length of the option-specific data
+    pub length: u16,
+
+    /// Option specific data
+    pub value: Vec<u8>,
+}
+
+impl Command for PutOptionCommand {
+    type ResponseType = PutOptionResponse;
+}
+
+/// Response from `commands::put_option`
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct PutOptionResponse {}
+
+impl Response for PutOptionResponse {
+    const COMMAND_TYPE: CommandType = CommandType::PutOption;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,9 @@ pub use commands::{
     generate_asymmetric_key::*, generate_hmac_key::*, generate_wrap_key::*, get_logs::*,
     get_object_info::*, get_opaque::*, get_option::*, get_pseudo_random::*, get_pubkey::*, hmac::*,
     import_wrapped::*, list_objects::*, put_asymmetric_key::*, put_auth_key::*, put_hmac_key::*,
-    put_opaque::*, put_otp_aead_key::*, put_wrap_key::*, reset::*, set_log_index::*, sign_ecdsa::*,
-    sign_eddsa::*, storage_status::*, unwrap_data::*, verify_hmac::*, wrap_data::*, CommandType,
+    put_opaque::*, put_option::*, put_otp_aead_key::*, put_wrap_key::*, reset::*, set_log_index::*,
+    sign_ecdsa::*, sign_eddsa::*, storage_status::*, unwrap_data::*, verify_hmac::*, wrap_data::*,
+    CommandType,
 };
 #[cfg(feature = "rsa")]
 pub use commands::{sign_rsa_pkcs1v15::*, sign_rsa_pss::*};

--- a/src/mockhsm/audit.rs
+++ b/src/mockhsm/audit.rs
@@ -1,0 +1,99 @@
+//! (Partial) support for audit logging within the MockHSM
+//!
+//! No logging is performed and these settings are not yet enforced
+
+use std::collections::BTreeMap;
+
+use audit::*;
+use commands::CommandType;
+use serializers;
+
+/// Default per-command auditing options
+pub const DEFAULT_COMMAND_AUDIT_OPTIONS: &[AuditCommand] = &[
+    AuditCommand(CommandType::Echo, AuditOption::Off),
+    AuditCommand(CommandType::CreateSession, AuditOption::On),
+    AuditCommand(CommandType::AuthSession, AuditOption::On),
+    AuditCommand(CommandType::SessionMessage, AuditOption::Off),
+    AuditCommand(CommandType::DeviceInfo, AuditOption::Off),
+    AuditCommand(CommandType::BSL, AuditOption::Off),
+    AuditCommand(CommandType::Command9, AuditOption::Off),
+    AuditCommand(CommandType::Reset, AuditOption::On),
+    AuditCommand(CommandType::CloseSession, AuditOption::On),
+    AuditCommand(CommandType::StorageStatus, AuditOption::On),
+    AuditCommand(CommandType::PutOpaqueObject, AuditOption::On),
+    AuditCommand(CommandType::GetOpaqueObject, AuditOption::On),
+    AuditCommand(CommandType::PutAuthKey, AuditOption::On),
+    AuditCommand(CommandType::PutAsymmetricKey, AuditOption::On),
+    AuditCommand(CommandType::GenerateAsymmetricKey, AuditOption::On),
+    AuditCommand(CommandType::SignDataPKCS1, AuditOption::On),
+    AuditCommand(CommandType::SignDataPSS, AuditOption::On),
+    AuditCommand(CommandType::SignDataECDSA, AuditOption::On),
+    AuditCommand(CommandType::ListObjects, AuditOption::On),
+    AuditCommand(CommandType::DecryptPKCS1, AuditOption::On),
+    AuditCommand(CommandType::DecryptECDH, AuditOption::On),
+    AuditCommand(CommandType::ExportWrapped, AuditOption::On),
+    AuditCommand(CommandType::ImportWrapped, AuditOption::On),
+    AuditCommand(CommandType::PutWrapKey, AuditOption::On),
+    AuditCommand(CommandType::GetLogs, AuditOption::Off),
+    AuditCommand(CommandType::SetLogIndex, AuditOption::On),
+    AuditCommand(CommandType::GetObjectInfo, AuditOption::On),
+    AuditCommand(CommandType::PutOption, AuditOption::On),
+    AuditCommand(CommandType::GetOption, AuditOption::On),
+    AuditCommand(CommandType::GetPseudoRandom, AuditOption::On),
+    AuditCommand(CommandType::PutHMACKey, AuditOption::On),
+    AuditCommand(CommandType::HMACData, AuditOption::On),
+    AuditCommand(CommandType::GetPubKey, AuditOption::On),
+    AuditCommand(CommandType::DeleteObject, AuditOption::On),
+    AuditCommand(CommandType::DecryptOAEP, AuditOption::On),
+    AuditCommand(CommandType::GenerateHMACKey, AuditOption::On),
+    AuditCommand(CommandType::GenerateWrapKey, AuditOption::On),
+    AuditCommand(CommandType::VerifyHMAC, AuditOption::On),
+    AuditCommand(CommandType::SSHCertify, AuditOption::On),
+    AuditCommand(CommandType::PutTemplate, AuditOption::On),
+    AuditCommand(CommandType::GetTemplate, AuditOption::On),
+    AuditCommand(CommandType::DecryptOTP, AuditOption::On),
+    AuditCommand(CommandType::CreateOTPAEAD, AuditOption::On),
+    AuditCommand(CommandType::RandomOTPAEAD, AuditOption::On),
+    AuditCommand(CommandType::RewrapOTPAEAD, AuditOption::On),
+    AuditCommand(CommandType::AttestAsymmetric, AuditOption::On),
+    AuditCommand(CommandType::PutOTPAEAD, AuditOption::On),
+    AuditCommand(CommandType::GenerateOTPAEAD, AuditOption::On),
+    AuditCommand(CommandType::WrapData, AuditOption::On),
+    AuditCommand(CommandType::UnwrapData, AuditOption::On),
+    AuditCommand(CommandType::SignDataEdDSA, AuditOption::On),
+    AuditCommand(CommandType::Blink, AuditOption::On),
+];
+
+/// Per-command auditing settings
+#[derive(Debug)]
+pub struct CommandAuditOptions(BTreeMap<CommandType, AuditOption>);
+
+impl CommandAuditOptions {
+    /// Serialize these audit options for use as a `GetObjects` response
+    pub fn serialize(&self) -> Vec<u8> {
+        let audit_commands: Vec<_> = self
+            .0
+            .iter()
+            .map(|(cmd, opt)| AuditCommand(*cmd, *opt))
+            .collect();
+
+        serializers::serialize(&audit_commands).unwrap()
+    }
+
+    /// Change a setting for a particular command
+    pub fn put(&mut self, command_type: CommandType, audit_option: AuditOption) {
+        self.0.insert(command_type, audit_option);
+    }
+}
+
+impl Default for CommandAuditOptions {
+    fn default() -> Self {
+        let mut result = BTreeMap::new();
+
+        for audit_command in DEFAULT_COMMAND_AUDIT_OPTIONS {
+            result.insert(audit_command.command_type(), audit_command.audit_option());
+        }
+
+        CommandAuditOptions(result)
+    }
+}

--- a/src/mockhsm/mod.rs
+++ b/src/mockhsm/mod.rs
@@ -8,6 +8,7 @@ use serde::{
 use std::sync::{Arc, Mutex};
 
 mod adapter;
+mod audit;
 mod commands;
 mod objects;
 mod session;

--- a/src/mockhsm/objects/mod.rs
+++ b/src/mockhsm/objects/mod.rs
@@ -7,8 +7,8 @@ mod payload;
 
 use failure::Error;
 use ring::aead::{self, OpeningKey, SealingKey, AES_128_GCM, AES_256_GCM};
-use std::collections::hash_map::Iter as HashMapIter;
-use std::collections::HashMap;
+use std::collections::btree_map::Iter as BTreeMapIter;
+use std::collections::BTreeMap;
 
 pub(crate) use self::payload::Payload;
 use auth_key::{AuthKey, AUTH_KEY_SIZE};
@@ -27,15 +27,15 @@ const WRAPPED_DATA_MAC_SIZE: usize = 16;
 const DEFAULT_AUTH_KEY_LABEL: &str = "DEFAULT AUTHKEY CHANGE THIS ASAP";
 
 /// Iterator over objects
-pub(crate) type Iter<'a> = HashMapIter<'a, ObjectHandle, Object>;
+pub(crate) type Iter<'a> = BTreeMapIter<'a, ObjectHandle, Object>;
 
 /// Objects stored in the `MockHSM`
 #[derive(Debug)]
-pub(crate) struct Objects(HashMap<ObjectHandle, Object>);
+pub(crate) struct Objects(BTreeMap<ObjectHandle, Object>);
 
 impl Default for Objects {
     fn default() -> Self {
-        let mut objects = HashMap::new();
+        let mut objects = BTreeMap::new();
 
         // Insert default authentication key
         let auth_key_handle = ObjectHandle::new(DEFAULT_AUTH_KEY_ID, ObjectType::AuthKey);

--- a/src/object/handle.rs
+++ b/src/object/handle.rs
@@ -2,7 +2,7 @@ use super::{ObjectId, ObjectType};
 
 /// Objects in the HSM are keyed by a tuple of their type an ObjectId
 /// (i.e. multiple objects of different types can have the same ObjectId)
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
 pub(crate) struct Handle {
     /// ID of the object
     pub object_id: ObjectId,

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -6,7 +6,7 @@ use serde::{
 use std::fmt;
 
 /// Types of objects
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum Type {
     /// Raw data
     Opaque = 0x01,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -115,8 +115,6 @@ impl<A: Adapter> Session<A> {
     /// Initialize a new encrypted session, deferring actually establishing
     /// a session until `connect()` is called
     pub fn new(config: A::Config, credentials: Credentials) -> Result<Self, SessionError> {
-        debug!("yubihsm: creating new session");
-
         let session = Self {
             config,
             connection: None,


### PR DESCRIPTION
Adds the following:

- `yubihsm::put_command_audit_option`: changes a command-specific audit setting to the specified value
- `yubihsm::put_force_audit_option`: changes the global force audit setting to the specified value