### PR TITLE
Decode detailed HSM errors from responses

### DIFF
--- a/src/commands/get_logs.rs
+++ b/src/commands/get_logs.rs
@@ -5,7 +5,7 @@
 use std::fmt::{self, Debug};
 
 use super::{Command, Response};
-use securechannel::ResponseCode;
+use response::ResponseCode;
 use {Adapter, CommandType, ObjectId, Session, SessionError};
 
 /// Get audit logs from the YubiHSM2 device

--- a/src/commands/set_log_index.rs
+++ b/src/commands/set_log_index.rs
@@ -1,4 +1,6 @@
-//! Set the index of the last consumed index of the `YubiHSM2` audit log
+//! Set the index of the last consumed entry in the `YubiHSM2` audit log.
+//! Useful in conjunction with the force audit option, which blocks HSM
+//! commands until audit data has been consumed from the device.
 //!
 //! <https://developers.yubico.com/YubiHSM2/Commands/Set_Log_Index.html>
 
@@ -18,7 +20,7 @@ pub fn set_log_index<A: Adapter>(
 /// Request parameters for `commands::set_log_index`
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct SetLogIndexCommand {
-    /// Number of seconds to set_log_index for
+    /// Index of the last log entry seen
     pub log_index: u16,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,9 @@ pub mod mockhsm;
 /// <https://developers.yubico.com/YubiHSM2/Concepts/Object.html>
 pub mod object;
 
+/// Responses to commands sent from the HSM
+pub mod response;
+
 /// Encrypted communication channel to the `YubiHSM2` hardware
 mod securechannel;
 
@@ -173,6 +176,7 @@ pub use commands::{sign_rsa_pkcs1v15::*, sign_rsa_pss::*};
 pub use credentials::Credentials;
 pub use domains::Domain;
 pub use object::*;
+pub use response::ResponseCode;
 pub use securechannel::SessionId;
 pub use serial::SerialNumber;
 #[cfg(feature = "usb")]

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,278 @@
+use failure::Error;
+use serde::de::{self, Deserialize, Deserializer, Visitor};
+use serde::ser::{Serialize, Serializer};
+use std::fmt;
+
+use commands::CommandType;
+
+/// Codes associated with `YubiHSM2` responses
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ResponseCode {
+    /// Successful response for the given command type
+    Success(CommandType),
+
+    /// HSM memory error (or generic error)
+    MemoryError,
+
+    /// Initialization error
+    InitError,
+
+    /// Network error
+    NetError,
+
+    /// Couldn't find connector
+    ConnectorNotFound,
+
+    /// Invalid parameters
+    InvalidParams,
+
+    /// Wrong length
+    WrongLength,
+
+    /// Buffer is too small
+    BufferTooSmall,
+
+    /// Cryptogram mismatches
+    CryptogramMismatch,
+
+    /// Session auth error
+    AuthSessionError,
+
+    /// MAC mismatch
+    MACMismatch,
+
+    /// OK (HSM)
+    DeviceOK,
+
+    /// Invalid command (HSM)
+    DeviceInvalidCommand,
+
+    /// Invalid data (HSM)
+    DeviceInvalidData,
+
+    /// Invalid session (HSM)
+    DeviceInvalidSession,
+
+    /// Authentication failure (HSM)
+    DeviceAuthFail,
+
+    /// Sessions full (HSM)
+    DeviceSessionsFull,
+
+    /// Session failed (HSM)
+    DeviceSessionFailed,
+
+    /// Storage failed (HSM)
+    DeviceStorageFailed,
+
+    /// Wrong length (HSM)
+    DeviceWrongLength,
+
+    /// Invalid permissions (HSM)
+    DeviceInvalidPermission,
+
+    /// Audit log full (HSM)
+    DeviceLogFull,
+
+    /// Object not found (HSM)
+    DeviceObjNotFound,
+
+    /// ID illegal (HSM)
+    DeviceIDIllegal,
+
+    /// Invalid OTP (HSM)
+    DeviceInvalidOTP,
+
+    /// Demo mode (HSM)
+    DeviceDemoMode,
+
+    /// Command unexecuted
+    DeviceCmdUnexecuted,
+
+    /// Generic error
+    GenericError,
+
+    /// Object already exists
+    DeviceObjectExists,
+
+    /// Connector error
+    ConnectorError,
+}
+
+impl ResponseCode {
+    /// Convert an unsigned byte into a ResponseCode (if valid)
+    pub fn from_u8(byte: u8) -> Result<Self, Error> {
+        let code = i16::from(byte).checked_sub(0x80).unwrap() as i8;
+
+        Ok(match code {
+            0...0x7F => ResponseCode::Success(CommandType::from_u8(code as u8)?),
+            -1 => ResponseCode::MemoryError,
+            -2 => ResponseCode::InitError,
+            -3 => ResponseCode::NetError,
+            -4 => ResponseCode::ConnectorNotFound,
+            -5 => ResponseCode::InvalidParams,
+            -6 => ResponseCode::WrongLength,
+            -7 => ResponseCode::BufferTooSmall,
+            -8 => ResponseCode::CryptogramMismatch,
+            -9 => ResponseCode::AuthSessionError,
+            -10 => ResponseCode::MACMismatch,
+            -11 => ResponseCode::DeviceOK,
+            -12 => ResponseCode::DeviceInvalidCommand,
+            -13 => ResponseCode::DeviceInvalidData,
+            -14 => ResponseCode::DeviceInvalidSession,
+            -15 => ResponseCode::DeviceAuthFail,
+            -16 => ResponseCode::DeviceSessionsFull,
+            -17 => ResponseCode::DeviceSessionFailed,
+            -18 => ResponseCode::DeviceStorageFailed,
+            -19 => ResponseCode::DeviceWrongLength,
+            -20 => ResponseCode::DeviceInvalidPermission,
+            -21 => ResponseCode::DeviceLogFull,
+            -22 => ResponseCode::DeviceObjNotFound,
+            -23 => ResponseCode::DeviceIDIllegal,
+            -24 => ResponseCode::DeviceInvalidOTP,
+            -25 => ResponseCode::DeviceDemoMode,
+            -26 => ResponseCode::DeviceCmdUnexecuted,
+            -27 => ResponseCode::GenericError,
+            -28 => ResponseCode::DeviceObjectExists,
+            -29 => ResponseCode::ConnectorError,
+            _ => bail!("invalid response code: {}", code),
+        })
+    }
+
+    /// Create a ResponseCode from the code found in an encrypted error
+    /// response body
+    pub fn from_device_code(byte: u8) -> Result<Self, Error> {
+        Ok(match byte {
+            0x00 => ResponseCode::DeviceOK,
+            0x01 => ResponseCode::DeviceInvalidCommand,
+            0x02 => ResponseCode::DeviceInvalidData,
+            0x03 => ResponseCode::DeviceInvalidSession,
+            0x04 => ResponseCode::DeviceAuthFail,
+            0x05 => ResponseCode::DeviceSessionsFull,
+            0x06 => ResponseCode::DeviceSessionFailed,
+            0x07 => ResponseCode::DeviceStorageFailed,
+            0x08 => ResponseCode::DeviceWrongLength,
+            0x09 => ResponseCode::DeviceInvalidPermission,
+            0x0a => ResponseCode::DeviceLogFull,
+            0x0b => ResponseCode::DeviceObjNotFound,
+            0x0c => ResponseCode::DeviceIDIllegal,
+            0x0d => ResponseCode::DeviceInvalidOTP,
+            0x0e => ResponseCode::DeviceDemoMode,
+            0x0f => ResponseCode::DeviceCmdUnexecuted,
+            other => bail!("unknown device code: {}", other),
+        })
+    }
+
+    /// Convert a ResponseCode back into its original byte form
+    pub fn to_u8(self) -> u8 {
+        let code: i8 = match self {
+            ResponseCode::Success(cmd_type) => cmd_type as i8,
+            ResponseCode::MemoryError => -1,
+            ResponseCode::InitError => -2,
+            ResponseCode::NetError => -3,
+            ResponseCode::ConnectorNotFound => -4,
+            ResponseCode::InvalidParams => -5,
+            ResponseCode::WrongLength => -6,
+            ResponseCode::BufferTooSmall => -7,
+            ResponseCode::CryptogramMismatch => -8,
+            ResponseCode::AuthSessionError => -9,
+            ResponseCode::MACMismatch => -10,
+            ResponseCode::DeviceOK => -11,
+            ResponseCode::DeviceInvalidCommand => -12,
+            ResponseCode::DeviceInvalidData => -13,
+            ResponseCode::DeviceInvalidSession => -14,
+            ResponseCode::DeviceAuthFail => -15,
+            ResponseCode::DeviceSessionsFull => -16,
+            ResponseCode::DeviceSessionFailed => -17,
+            ResponseCode::DeviceStorageFailed => -18,
+            ResponseCode::DeviceWrongLength => -19,
+            ResponseCode::DeviceInvalidPermission => -20,
+            ResponseCode::DeviceLogFull => -21,
+            ResponseCode::DeviceObjNotFound => -22,
+            ResponseCode::DeviceIDIllegal => -23,
+            ResponseCode::DeviceInvalidOTP => -24,
+            ResponseCode::DeviceDemoMode => -25,
+            ResponseCode::DeviceCmdUnexecuted => -26,
+            ResponseCode::GenericError => -27,
+            ResponseCode::DeviceObjectExists => -28,
+            ResponseCode::ConnectorError => -29,
+        };
+
+        (i16::from(code) + 0x80) as u8
+    }
+
+    /// Convert this response code to a device response code for inclusion
+    /// in an error response message body
+    #[cfg(feature = "mockhsm")]
+    pub fn to_device_code(self) -> u8 {
+        match self {
+            ResponseCode::DeviceOK => 0x00,
+            ResponseCode::DeviceInvalidCommand => 0x01,
+            ResponseCode::DeviceInvalidData => 0x02,
+            ResponseCode::DeviceInvalidSession => 0x03,
+            ResponseCode::DeviceAuthFail => 0x04,
+            ResponseCode::DeviceSessionsFull => 0x05,
+            ResponseCode::DeviceSessionFailed => 0x06,
+            ResponseCode::DeviceStorageFailed => 0x07,
+            ResponseCode::DeviceWrongLength => 0x08,
+            ResponseCode::DeviceInvalidPermission => 0x09,
+            ResponseCode::DeviceLogFull => 0x0a,
+            ResponseCode::DeviceObjNotFound => 0x0b,
+            ResponseCode::DeviceIDIllegal => 0x0c,
+            ResponseCode::DeviceInvalidOTP => 0x0d,
+            ResponseCode::DeviceDemoMode => 0x0e,
+            ResponseCode::DeviceCmdUnexecuted => 0x0f,
+            other => panic!("not a valid device code: {:?}", other),
+        }
+    }
+
+    /// Is this a successful response?
+    pub fn is_success(self) -> bool {
+        match self {
+            ResponseCode::Success(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Is this an error response?
+    pub fn is_err(self) -> bool {
+        !self.is_success()
+    }
+}
+
+impl Serialize for ResponseCode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(self.to_u8())
+    }
+}
+
+impl<'de> Deserialize<'de> for ResponseCode {
+    fn deserialize<D>(deserializer: D) -> Result<ResponseCode, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ResponseCodeVisitor;
+
+        impl<'de> Visitor<'de> for ResponseCodeVisitor {
+            type Value = ResponseCode;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an unsigned byte between 0x01 and 0x07")
+            }
+
+            fn visit_u8<E>(self, value: u8) -> Result<ResponseCode, E>
+            where
+                E: de::Error,
+            {
+                ResponseCode::from_u8(value)
+                    .or_else(|_| ResponseCode::from_u8(ResponseCode::DeviceOK.to_u8() - value))
+                    .or_else(|e| Err(E::custom(format!("{}", e))))
+            }
+        }
+
+        deserializer.deserialize_u8(ResponseCodeVisitor)
+    }
+}

--- a/src/securechannel/mod.rs
+++ b/src/securechannel/mod.rs
@@ -46,4 +46,4 @@ pub use self::context::{Context, CONTEXT_SIZE};
 pub use self::cryptogram::{Cryptogram, CRYPTOGRAM_SIZE};
 pub use self::error::{SecureChannelError, SecureChannelErrorKind};
 pub(crate) use self::mac::{Mac, MAC_SIZE};
-pub(crate) use self::response::{ResponseCode, ResponseMessage};
+pub(crate) use self::response::ResponseMessage;

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -2,6 +2,7 @@
 
 use adapters::AdapterError;
 use error::Error;
+use response::ResponseCode;
 use securechannel::SecureChannelError;
 use serializers::SerializationError;
 
@@ -13,7 +14,7 @@ pub type SessionError = Error<SessionErrorKind>;
 pub enum SessionErrorKind {
     /// Couldn't authenticate session
     #[fail(display = "authentication failed")]
-    AuthFailed,
+    AuthFail,
 
     /// Session is closed
     #[fail(display = "session closed")]
@@ -23,17 +24,65 @@ pub enum SessionErrorKind {
     #[fail(display = "couldn't create session")]
     CreateFailed,
 
+    /// Command not valid
+    #[fail(display = "invalid command")]
+    CommandInvalid,
+
+    /// Data not valid
+    #[fail(display = "invalid data")]
+    DataInvalid,
+
+    /// ID illegal
+    #[fail(display = "ID illegal")]
+    IDIllegal,
+
+    /// HSM audit log is full; can't complete command
+    #[fail(display = "HSM audit log full")]
+    LogFull,
+
+    /// The requested object was not found
+    #[fail(display = "object not found")]
+    ObjNotFound,
+
+    /// One Time Password is invalid
+    #[fail(display = "OTP invalid")]
+    OTPInvalid,
+
+    /// Incorrect permissions to complete operation
+    #[fail(display = "access denied: invalid permissions")]
+    PermissionInvalid,
+
     /// Protocol error occurred
     #[fail(display = "protocol error")]
     ProtocolError,
 
-    /// HSM returned an error response
-    #[fail(display = "bad HSM response")]
+    /// Error response from HSM we can't further specify
+    #[fail(display = "HSM error")]
     ResponseError,
+
+    /// Session with HSM failed
+    #[fail(display = "session failed")]
+    SessionFailed,
+
+    /// Session with HSM invalid
+    #[fail(display = "invalid session")]
+    SessionInvalid,
+
+    /// HSM exceeded maximum number of sessions (16)
+    #[fail(display = "HSM sessions full (max 16)")]
+    SessionsFull,
+
+    /// HSM storage failure
+    #[fail(display = "HSM storage failure")]
+    StorageFailed,
 
     /// Session with the YubiHSM2 timed out
     #[fail(display = "session timeout")]
     TimeoutError,
+
+    /// Length incorrect for operation
+    #[fail(display = "wrong length")]
+    WrongLength,
 }
 
 impl From<AdapterError> for SessionError {
@@ -51,5 +100,30 @@ impl From<SecureChannelError> for SessionError {
 impl From<SerializationError> for SessionError {
     fn from(err: SerializationError) -> Self {
         err!(SessionErrorKind::ProtocolError, err.to_string())
+    }
+}
+
+impl From<ResponseCode> for SessionError {
+    fn from(code: ResponseCode) -> Self {
+        let kind = match code {
+            ResponseCode::Success(cmd) => panic!("not an error: ResponseCode::Success({:?})", cmd),
+            ResponseCode::DeviceOK => panic!("expected an error response, got DeviceOK"),
+            ResponseCode::DeviceInvalidCommand => SessionErrorKind::CommandInvalid,
+            ResponseCode::DeviceInvalidData => SessionErrorKind::DataInvalid,
+            ResponseCode::DeviceInvalidSession => SessionErrorKind::SessionInvalid,
+            ResponseCode::DeviceAuthFail => SessionErrorKind::AuthFail,
+            ResponseCode::DeviceSessionsFull => SessionErrorKind::SessionsFull,
+            ResponseCode::DeviceSessionFailed => SessionErrorKind::SessionFailed,
+            ResponseCode::DeviceStorageFailed => SessionErrorKind::StorageFailed,
+            ResponseCode::DeviceWrongLength => SessionErrorKind::WrongLength,
+            ResponseCode::DeviceInvalidPermission => SessionErrorKind::PermissionInvalid,
+            ResponseCode::DeviceLogFull => SessionErrorKind::LogFull,
+            ResponseCode::DeviceObjNotFound => SessionErrorKind::ObjNotFound,
+            ResponseCode::DeviceIDIllegal => SessionErrorKind::IDIllegal,
+            ResponseCode::DeviceInvalidOTP => SessionErrorKind::OTPInvalid,
+            _ => SessionErrorKind::ResponseError,
+        };
+
+        Error::new(kind, None)
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -189,7 +189,7 @@ impl<A: Adapter> Session<A> {
             &self.config,
             self.credentials
                 .as_ref()
-                .ok_or_else(|| err!(AuthFailed, "session reconnection disabled"))?,
+                .ok_or_else(|| err!(AuthFail, "session reconnection disabled"))?,
         )?;
 
         self.connection = Some(connection);

--- a/src/session/timeout.rs
+++ b/src/session/timeout.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 /// <https://developers.yubico.com/YubiHSM2/Concepts/Session.html>
 pub const SESSION_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Timeouts when performing USB operations
+/// Session timeouts (i.e. YubiHSM's session inactivity timeout)
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct SessionTimeout(Duration);
 
@@ -25,8 +25,8 @@ impl SessionTimeout {
     }
 }
 
-/// Default timeout
 impl Default for SessionTimeout {
+    /// Default timeout: 30 seconds
     fn default() -> Self {
         Self::new(SESSION_INACTIVITY_TIMEOUT)
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -367,10 +367,9 @@ fn get_object_info_default_authkey() {
 #[test]
 fn get_command_audit_options_test() {
     let mut session = create_session!();
+
     let results = yubihsm::get_all_command_audit_options(&mut session)
         .unwrap_or_else(|err| panic!("error getting force option: {}", err));
-
-    println!("results: {:?}", &results);
 
     assert!(results.len() > 1);
 }
@@ -379,6 +378,7 @@ fn get_command_audit_options_test() {
 #[test]
 fn get_force_audit_option_test() {
     let mut session = create_session!();
+
     yubihsm::get_force_audit_option(&mut session)
         .unwrap_or_else(|err| panic!("error getting force option: {}", err));
 }


### PR DESCRIPTION
The HSM sends us information about errors which occur in response to commands which was previously not being decoded.

This commit decodes that information and surfaces it through the `SessionErrorKind` enum.