### PR TITLE
Factor `integration.rs` tests into separate submodules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,14 @@ uuid = { version = "0.6", default-features = false }
 [dev-dependencies]
 criterion = "0.2"
 lazy_static = "1"
+ring = "0.13"
+untrusted = "0.6"
 
 [features]
 aes-soft = ["aes/force_soft"]
 doc = ["mockhsm", "rsa", "usb"]
 default = ["passwords"]
-integration = ["ring", "untrusted"]
-mockhsm = ["integration", "passwords"]
+mockhsm = ["passwords", "ring", "untrusted"]
 nightly = ["clear_on_drop/nightly", "subtle/nightly"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 rsa = ["sha2"]

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ a [MockHSM] service which reimplements some YubiHSM2 functionality in software.
 
 [MockHSM]: https://docs.rs/yubihsm/latest/yubihsm/mockhsm/struct.MockHSM.html
 
-### `cargo test --features=integration`: test YubiHSM2 live via `yubihsm-connector`
+### `cargo test`: test YubiHSM2 live via `yubihsm-connector`
 
 This mode assumes you have a YubiHSM2 hardware device, have downloaded the
 [YubiHSM2 SDK] for your platform, and are running a **yubihsm-connector**
@@ -233,7 +233,7 @@ blinking rapidly for 1 second.
 **NOTE THAT THESE TESTS ARE DESTRUCTIVE: DO NOT RUN THEM AGAINST A YUBIHSM2
 WHICH CONTAINS KEYS YOU CARE ABOUT**
 
-### `cargo test --features=usb,integration`: test YubiHSM2 live via USB
+### `cargo test --features=usb`: test YubiHSM2 live via USB
 
 Adding the `usb` cargo feature builds the `UsbAdapter` backend in addition
 to the `HttpAdapter`, and also runs the test suite live via USB rather than

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -149,42 +149,59 @@ bitflags! {
         /// wrap_data: wrap user-provided data
         const WRAP_DATA = 0x20_0000_0000;
 
-        /// Unknown Capability bit 46
-        const UNKNOWN_BIT46 = 0x4000_0000_0000;
-        /// Unknown Capability bit 47
-        const UNKNOWN_BIT47 = 0x8000_0000_0000;
-        /// Unknown Capability bit 48
-        const UNKNOWN_BIT48 = 0x1_0000_0000_0000;
-        /// Unknown Capability bit 49
-        const UNKNOWN_BIT49 = 0x2_0000_0000_0000;
-        /// Unknown Capability bit 50
-        const UNKNOWN_BIT50 = 0x4_0000_0000_0000;
-        /// Unknown Capability bit 51
-        const UNKNOWN_BIT51 = 0x8_0000_0000_0000;
-        /// Unknown Capability bit 52
-        const UNKNOWN_BIT52 = 0x10_0000_0000_0000;
-        /// Unknown Capability bit 53
-        const UNKNOWN_BIT53 = 0x20_0000_0000_0000;
-        /// Unknown Capability bit 54
-        const UNKNOWN_BIT54 = 0x40_0000_0000_0000;
-        /// Unknown Capability bit 55
-        const UNKNOWN_BIT55 = 0x80_0000_0000_0000;
-        /// Unknown Capability bit 56
-        const UNKNOWN_BIT56 = 0x100_0000_0000_0000;
-        /// Unknown Capability bit 57
-        const UNKNOWN_BIT57 = 0x200_0000_0000_0000;
-        /// Unknown Capability bit 58
-        const UNKNOWN_BIT58 = 0x400_0000_0000_0000;
-        /// Unknown Capability bit 59
-        const UNKNOWN_BIT59 = 0x800_0000_0000_0000;
-        /// Unknown Capability bit 60
-        const UNKNOWN_BIT60 = 0x1000_0000_0000_0000;
-        /// Unknown Capability bit 61
-        const UNKNOWN_BIT61 = 0x2000_0000_0000_0000;
-        /// Unknown Capability bit 62
-        const UNKNOWN_BIT62 = 0x4000_0000_0000_0000;
-        /// Unknown Capability bit 63
-        const UNKNOWN_BIT63 = 0x8000_0000_0000_0000;
+        /// Unknown Capability (Bit 46)
+        const CAP46 = 0x4000_0000_0000;
+
+        /// Unknown Capability (Bit 47)
+        const CAP47 = 0x8000_0000_0000;
+
+        /// Unknown Capability (Bit 48)
+        const CAP48 = 0x1_0000_0000_0000;
+
+        /// Unknown Capability (Bit 49)
+        const CAP49 = 0x2_0000_0000_0000;
+
+        /// Unknown Capability (Bit 50)
+        const CAP50 = 0x4_0000_0000_0000;
+
+        /// Unknown Capability (Bit 51)
+        const CAP51 = 0x8_0000_0000_0000;
+
+        /// Unknown Capability (Bit 52)
+        const CAP52 = 0x10_0000_0000_0000;
+
+        /// Unknown Capability (Bit 53)
+        const CAP53 = 0x20_0000_0000_0000;
+
+        /// Unknown Capability (Bit 54)
+        const CAP54 = 0x40_0000_0000_0000;
+
+        /// Unknown Capability (Bit 55)
+        const CAP55 = 0x80_0000_0000_0000;
+
+        /// Unknown Capability (Bit 56)
+        const CAP56 = 0x100_0000_0000_0000;
+
+        /// Unknown Capability (Bit 57)
+        const CAP57 = 0x200_0000_0000_0000;
+
+        /// Unknown Capability (Bit 58)
+        const CAP58 = 0x400_0000_0000_0000;
+
+        /// Unknown Capability (Bit 59)
+        const CAP59 = 0x800_0000_0000_0000;
+
+        /// Unknown Capability (Bit 60)
+        const CAP60 = 0x1000_0000_0000_0000;
+
+        /// Unknown Capability (Bit 61)
+        const CAP61 = 0x2000_0000_0000_0000;
+
+        /// Unknown Capability (Bit 62)
+        const CAP62 = 0x4000_0000_0000_0000;
+
+        /// Unknown Capability (Bit 63)
+        const CAP63 = 0x8000_0000_0000_0000;
     }
 }
 

--- a/tests/commands/attest_asymmetric.rs
+++ b/tests/commands/attest_asymmetric.rs
@@ -1,0 +1,21 @@
+use yubihsm::{self, AsymmetricAlgorithm, Capability};
+
+use {generate_asymmetric_key, EC_P256_PUBLIC_KEY_SIZE, TEST_KEY_ID};
+
+/// Generate an attestation about a key in the HSM
+#[test]
+fn attest_asymmetric_test() {
+    let mut session = create_session!();
+
+    generate_asymmetric_key(
+        &mut session,
+        AsymmetricAlgorithm::EC_P256,
+        Capability::ASYMMETRIC_SIGN_ECDSA,
+    );
+
+    let certificate = yubihsm::attest_asymmetric(&mut session, TEST_KEY_ID, None)
+        .unwrap_or_else(|err| panic!("error getting attestation certificate: {}", err));
+
+    // TODO: more tests, e.g. test that the certificate validates
+    assert!(certificate.len() > EC_P256_PUBLIC_KEY_SIZE);
+}

--- a/tests/commands/blink.rs
+++ b/tests/commands/blink.rs
@@ -1,0 +1,8 @@
+use yubihsm;
+
+/// Blink the LED on the YubiHSM for 2 seconds
+#[test]
+fn blink_test() {
+    let mut session = create_session!();
+    yubihsm::blink(&mut session, 2).unwrap();
+}

--- a/tests/commands/delete_object.rs
+++ b/tests/commands/delete_object.rs
@@ -1,0 +1,21 @@
+use yubihsm::{self, AsymmetricAlgorithm, Capability, ObjectType};
+
+use {generate_asymmetric_key, TEST_KEY_ID};
+
+/// Delete an object in the YubiHSM2
+#[test]
+fn delete_object_test() {
+    let mut session = create_session!();
+
+    generate_asymmetric_key(
+        &mut session,
+        AsymmetricAlgorithm::EC_ED25519,
+        Capability::ASYMMETRIC_SIGN_EDDSA,
+    );
+
+    // The first request to delete should succeed because the object exists
+    assert!(yubihsm::delete_object(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey).is_ok());
+
+    // The second request to delete should fail because it's already deleted
+    assert!(yubihsm::delete_object(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey).is_err());
+}

--- a/tests/commands/device_info.rs
+++ b/tests/commands/device_info.rs
@@ -1,0 +1,14 @@
+use yubihsm;
+
+/// Get device information
+#[test]
+fn device_info_test() {
+    let mut session = create_session!();
+
+    let device_info = yubihsm::device_info(&mut session)
+        .unwrap_or_else(|err| panic!("error getting device info: {}", err));
+
+    assert_eq!(device_info.major_version, 2);
+    assert_eq!(device_info.minor_version, 0);
+    assert_eq!(device_info.build_version, 0);
+}

--- a/tests/commands/echo.rs
+++ b/tests/commands/echo.rs
@@ -1,0 +1,14 @@
+use yubihsm;
+
+use TEST_MESSAGE;
+
+/// Send a simple echo request
+#[test]
+fn echo_test() {
+    let mut session = create_session!();
+
+    let echo_response = yubihsm::echo(&mut session, TEST_MESSAGE)
+        .unwrap_or_else(|err| panic!("error sending echo: {}", err));
+
+    assert_eq!(TEST_MESSAGE, echo_response.as_slice());
+}

--- a/tests/commands/export_wrapped.rs
+++ b/tests/commands/export_wrapped.rs
@@ -1,0 +1,80 @@
+use yubihsm::{self, AsymmetricAlgorithm, Capability, ObjectOrigin, ObjectType, WrapAlgorithm};
+
+use test_vectors::AESCCM_TEST_VECTORS;
+use {
+    clear_test_key_slot, TEST_DOMAINS, TEST_EXPORTED_KEY_ID, TEST_EXPORTED_KEY_LABEL, TEST_KEY_ID,
+    TEST_KEY_LABEL,
+};
+
+/// Test wrap key workflow using randomly generated keys
+// TODO: test against RFC 3610 vectors
+#[test]
+fn wrap_key_test() {
+    let mut session = create_session!();
+    let algorithm = WrapAlgorithm::AES128_CCM_WRAP;
+    let capabilities = Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED;
+    let delegated_capabilities = Capability::all();
+
+    clear_test_key_slot(&mut session, ObjectType::WrapKey);
+
+    let key_id = yubihsm::put_wrap_key(
+        &mut session,
+        TEST_KEY_ID,
+        TEST_KEY_LABEL.into(),
+        TEST_DOMAINS,
+        capabilities,
+        delegated_capabilities,
+        algorithm,
+        AESCCM_TEST_VECTORS[0].key,
+    ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
+
+    assert_eq!(key_id, TEST_KEY_ID);
+
+    // Create a key to export
+    let exported_key_type = ObjectType::AsymmetricKey;
+    let exported_key_capabilities =
+        Capability::ASYMMETRIC_SIGN_EDDSA | Capability::EXPORT_UNDER_WRAP;
+    let exported_key_algorithm = AsymmetricAlgorithm::EC_ED25519;
+
+    let _ = yubihsm::delete_object(&mut session, TEST_EXPORTED_KEY_ID, exported_key_type);
+    yubihsm::generate_asymmetric_key(
+        &mut session,
+        TEST_EXPORTED_KEY_ID,
+        TEST_EXPORTED_KEY_LABEL.into(),
+        TEST_DOMAINS,
+        exported_key_capabilities,
+        exported_key_algorithm,
+    ).unwrap_or_else(|err| panic!("error generating asymmetric key: {}", err));
+
+    let wrap_data = yubihsm::export_wrapped(
+        &mut session,
+        TEST_KEY_ID,
+        exported_key_type,
+        TEST_EXPORTED_KEY_ID,
+    ).unwrap_or_else(|err| panic!("error exporting key: {}", err));
+
+    // Delete the object from the HSM prior to re-importing it
+    assert!(yubihsm::delete_object(&mut session, TEST_EXPORTED_KEY_ID, exported_key_type).is_ok());
+
+    // Re-import the wrapped key back into the HSM
+    let import_response = yubihsm::import_wrapped(&mut session, TEST_KEY_ID, wrap_data)
+        .unwrap_or_else(|err| panic!("error importing key: {}", err));
+
+    assert_eq!(import_response.object_type, exported_key_type);
+    assert_eq!(import_response.object_id, TEST_EXPORTED_KEY_ID);
+
+    let imported_key_info =
+        yubihsm::get_object_info(&mut session, TEST_EXPORTED_KEY_ID, exported_key_type)
+            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(imported_key_info.capabilities, exported_key_capabilities);
+    assert_eq!(imported_key_info.object_id, TEST_EXPORTED_KEY_ID);
+    assert_eq!(imported_key_info.domains, TEST_DOMAINS);
+    assert_eq!(imported_key_info.object_type, exported_key_type);
+    assert_eq!(imported_key_info.algorithm, exported_key_algorithm.into());
+    assert_eq!(imported_key_info.origin, ObjectOrigin::WrappedGenerated);
+    assert_eq!(
+        &imported_key_info.label.to_string().unwrap(),
+        TEST_EXPORTED_KEY_LABEL
+    );
+}

--- a/tests/commands/generate_asymmetric_key.rs
+++ b/tests/commands/generate_asymmetric_key.rs
@@ -1,0 +1,48 @@
+use yubihsm::{self, AsymmetricAlgorithm, Capability, ObjectOrigin, ObjectType};
+
+use {generate_asymmetric_key, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
+
+/// Generate an Ed25519 key
+#[test]
+fn ed25519_key_test() {
+    let mut session = create_session!();
+
+    let algorithm = AsymmetricAlgorithm::EC_ED25519;
+    let capabilities = Capability::ASYMMETRIC_SIGN_EDDSA;
+
+    generate_asymmetric_key(&mut session, algorithm, capabilities);
+
+    let object_info =
+        yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey)
+            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, ObjectType::AsymmetricKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Generated);
+    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
+}
+
+/// Generate a NIST P-256 key
+#[test]
+fn nistp256_key_test() {
+    let mut session = create_session!();
+    let algorithm = AsymmetricAlgorithm::EC_P256;
+    let capabilities = Capability::ASYMMETRIC_SIGN_EDDSA;
+
+    generate_asymmetric_key(&mut session, algorithm, capabilities);
+
+    let object_info =
+        yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey)
+            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, ObjectType::AsymmetricKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Generated);
+    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
+}

--- a/tests/commands/generate_hmac_key.rs
+++ b/tests/commands/generate_hmac_key.rs
@@ -1,0 +1,36 @@
+use yubihsm::{self, Capability, HMACAlgorithm, ObjectOrigin, ObjectType};
+
+use {clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
+
+/// Generate an HMAC key
+#[test]
+fn hmac_key_test() {
+    let mut session = create_session!();
+
+    let algorithm = HMACAlgorithm::HMAC_SHA256;
+    let capabilities = Capability::HMAC_DATA | Capability::HMAC_VERIFY;
+
+    clear_test_key_slot(&mut session, ObjectType::HMACKey);
+
+    let key_id = yubihsm::generate_hmac_key(
+        &mut session,
+        TEST_KEY_ID,
+        TEST_KEY_LABEL.into(),
+        TEST_DOMAINS,
+        capabilities,
+        algorithm,
+    ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
+
+    assert_eq!(key_id, TEST_KEY_ID);
+
+    let object_info = yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::HMACKey)
+        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, ObjectType::HMACKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Generated);
+    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
+}

--- a/tests/commands/generate_wrap_key.rs
+++ b/tests/commands/generate_wrap_key.rs
@@ -1,0 +1,41 @@
+use yubihsm::{self, Capability, ObjectOrigin, ObjectType, WrapAlgorithm};
+
+use {clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
+
+/// Generate an AES-CCM key wrapping key
+#[test]
+fn wrap_key_test() {
+    let mut session = create_session!();
+
+    let algorithm = WrapAlgorithm::AES256_CCM_WRAP;
+    let capabilities = Capability::EXPORT_WRAPPED
+        | Capability::IMPORT_WRAPPED
+        | Capability::UNWRAP_DATA
+        | Capability::WRAP_DATA;
+    let delegated_capabilities = Capability::all();
+
+    clear_test_key_slot(&mut session, ObjectType::WrapKey);
+
+    let key_id = yubihsm::generate_wrap_key(
+        &mut session,
+        TEST_KEY_ID,
+        TEST_KEY_LABEL.into(),
+        TEST_DOMAINS,
+        capabilities,
+        delegated_capabilities,
+        algorithm,
+    ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
+
+    assert_eq!(key_id, TEST_KEY_ID);
+
+    let object_info = yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::WrapKey)
+        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, ObjectType::WrapKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Generated);
+    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
+}

--- a/tests/commands/get_logs.rs
+++ b/tests/commands/get_logs.rs
@@ -1,0 +1,11 @@
+use yubihsm;
+
+/// Get audit log
+#[test]
+fn get_audit_logs_test() {
+    let mut session = create_session!();
+
+    // TODO: test audit logging functionality
+    yubihsm::get_audit_logs(&mut session)
+        .unwrap_or_else(|err| panic!("error getting logs: {}", err));
+}

--- a/tests/commands/get_object_info.rs
+++ b/tests/commands/get_object_info.rs
@@ -1,0 +1,25 @@
+use yubihsm::credentials::DEFAULT_AUTH_KEY_ID;
+use yubihsm::{self, AuthAlgorithm, Capability, Domain, ObjectOrigin, ObjectType};
+
+use DEFAULT_AUTH_KEY_LABEL;
+
+/// Get object info on default auth key
+#[test]
+fn default_authkey_test() {
+    let mut session = create_session!();
+
+    let object_info =
+        yubihsm::get_object_info(&mut session, DEFAULT_AUTH_KEY_ID, ObjectType::AuthKey)
+            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, Capability::all());
+    assert_eq!(object_info.object_id, DEFAULT_AUTH_KEY_ID);
+    assert_eq!(object_info.domains, Domain::all());
+    assert_eq!(object_info.object_type, ObjectType::AuthKey);
+    assert_eq!(object_info.algorithm, AuthAlgorithm::YUBICO_AES_AUTH.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Imported);
+    assert_eq!(
+        &object_info.label.to_string().unwrap(),
+        DEFAULT_AUTH_KEY_LABEL
+    );
+}

--- a/tests/commands/get_options.rs
+++ b/tests/commands/get_options.rs
@@ -1,0 +1,21 @@
+use yubihsm;
+
+/// Get the auditing options for all commands
+#[test]
+fn command_audit_options_test() {
+    let mut session = create_session!();
+
+    let results = yubihsm::get_all_command_audit_options(&mut session)
+        .unwrap_or_else(|err| panic!("error getting force option: {}", err));
+
+    assert!(results.len() > 1);
+}
+
+/// Get the "force audit" option setting
+#[test]
+fn force_audit_option_test() {
+    let mut session = create_session!();
+
+    yubihsm::get_force_audit_option(&mut session)
+        .unwrap_or_else(|err| panic!("error getting force option: {}", err));
+}

--- a/tests/commands/get_pseudo_random.rs
+++ b/tests/commands/get_pseudo_random.rs
@@ -1,0 +1,12 @@
+use yubihsm;
+
+/// Get random bytes
+#[test]
+fn get_pseudo_random_test() {
+    let mut session = create_session!();
+
+    let bytes = yubihsm::get_pseudo_random(&mut session, 32)
+        .unwrap_or_else(|err| panic!("error getting random data: {}", err));
+
+    assert_eq!(32, bytes.len());
+}

--- a/tests/commands/list_objects.rs
+++ b/tests/commands/list_objects.rs
@@ -1,0 +1,26 @@
+use yubihsm::{self, AsymmetricAlgorithm, Capability, ObjectType};
+
+use {generate_asymmetric_key, TEST_KEY_ID};
+
+/// List the objects in the YubiHSM2
+#[test]
+fn list_objects_test() {
+    let mut session = create_session!();
+
+    generate_asymmetric_key(
+        &mut session,
+        AsymmetricAlgorithm::EC_ED25519,
+        Capability::ASYMMETRIC_SIGN_EDDSA,
+    );
+
+    let objects = yubihsm::list_objects(&mut session)
+        .unwrap_or_else(|err| panic!("error listing objects: {}", err));
+
+    // Look for the asymmetric key we just generated
+    assert!(
+        objects
+            .iter()
+            .find(|i| i.object_id == TEST_KEY_ID && i.object_type == ObjectType::AsymmetricKey)
+            .is_some()
+    );
+}

--- a/tests/commands/mod.rs
+++ b/tests/commands/mod.rs
@@ -1,0 +1,26 @@
+//! Integration tests for YubiHSM2 commands
+
+#[cfg(not(feature = "mockhsm"))]
+pub mod attest_asymmetric;
+pub mod blink;
+pub mod delete_object;
+pub mod device_info;
+pub mod export_wrapped;
+pub mod generate_asymmetric_key;
+pub mod generate_hmac_key;
+pub mod generate_wrap_key;
+pub mod get_logs;
+pub mod get_object_info;
+pub mod get_options;
+pub mod get_pseudo_random;
+pub mod list_objects;
+pub mod put_asymmetric_key;
+pub mod put_auth_key;
+pub mod put_opaque;
+pub mod put_options;
+#[cfg(feature = "mockhsm")]
+pub mod reset;
+pub mod sign_ecdsa;
+pub mod sign_eddsa;
+pub mod storage_status;
+pub mod verify_hmac;

--- a/tests/commands/put_asymmetric_key.rs
+++ b/tests/commands/put_asymmetric_key.rs
@@ -1,0 +1,27 @@
+use yubihsm::{self, AsymmetricAlgorithm, Capability, ObjectOrigin, ObjectType};
+
+use test_vectors::ED25519_TEST_VECTORS;
+use {put_asymmetric_key, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
+
+/// Put an Ed25519 key
+#[test]
+fn ed25519_key_test() {
+    let mut session = create_session!();
+    let algorithm = AsymmetricAlgorithm::EC_ED25519;
+    let capabilities = Capability::ASYMMETRIC_SIGN_EDDSA;
+    let example_private_key = ED25519_TEST_VECTORS[0].sk;
+
+    put_asymmetric_key(&mut session, algorithm, capabilities, example_private_key);
+
+    let object_info =
+        yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey)
+            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, ObjectType::AsymmetricKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Imported);
+    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
+}

--- a/tests/commands/put_auth_key.rs
+++ b/tests/commands/put_auth_key.rs
@@ -1,0 +1,40 @@
+use yubihsm::{self, AuthAlgorithm, AuthKey, Capability, ObjectOrigin, ObjectType};
+
+use {clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL, TEST_MESSAGE};
+
+/// Put a new authentication key into the `YubiHSM`
+#[test]
+fn put_auth_key() {
+    let mut session = create_session!();
+    let algorithm = AuthAlgorithm::YUBICO_AES_AUTH;
+    let capabilities = Capability::all();
+    let delegated_capabilities = Capability::all();
+
+    clear_test_key_slot(&mut session, ObjectType::AuthKey);
+
+    let new_auth_key = AuthKey::derive_from_password(TEST_MESSAGE);
+
+    let key_id = yubihsm::put_auth_key(
+        &mut session,
+        TEST_KEY_ID,
+        TEST_KEY_LABEL.into(),
+        TEST_DOMAINS,
+        capabilities,
+        delegated_capabilities,
+        algorithm,
+        new_auth_key,
+    ).unwrap_or_else(|err| panic!("error putting auth key: {}", err));
+
+    assert_eq!(key_id, TEST_KEY_ID);
+
+    let object_info = yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AuthKey)
+        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
+
+    assert_eq!(object_info.capabilities, capabilities);
+    assert_eq!(object_info.object_id, TEST_KEY_ID);
+    assert_eq!(object_info.domains, TEST_DOMAINS);
+    assert_eq!(object_info.object_type, ObjectType::AuthKey);
+    assert_eq!(object_info.algorithm, algorithm.into());
+    assert_eq!(object_info.origin, ObjectOrigin::Imported);
+    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
+}

--- a/tests/commands/put_opaque.rs
+++ b/tests/commands/put_opaque.rs
@@ -1,0 +1,28 @@
+use yubihsm::{self, Capability, ObjectType, OpaqueAlgorithm};
+
+use {clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL, TEST_MESSAGE};
+
+/// Put an opaque object and read it back
+#[test]
+fn opaque_object_test() {
+    let mut session = create_session!();
+
+    clear_test_key_slot(&mut session, ObjectType::Opaque);
+
+    let object_id = yubihsm::put_opaque(
+        &mut session,
+        TEST_KEY_ID,
+        TEST_KEY_LABEL.into(),
+        TEST_DOMAINS,
+        Capability::default(),
+        OpaqueAlgorithm::OPAQUE_DATA,
+        TEST_MESSAGE,
+    ).unwrap_or_else(|err| panic!("error putting opaque object: {}", err));
+
+    assert_eq!(object_id, TEST_KEY_ID);
+
+    let opaque_data = yubihsm::get_opaque(&mut session, TEST_KEY_ID)
+        .unwrap_or_else(|err| panic!("error getting opaque object: {}", err));
+
+    assert_eq!(opaque_data, TEST_MESSAGE);
+}

--- a/tests/commands/put_options.rs
+++ b/tests/commands/put_options.rs
@@ -1,0 +1,44 @@
+use yubihsm::{self, AuditOption, CommandType};
+
+/// Set the auditing options for a particular command
+#[test]
+fn command_audit_options_test() {
+    let mut session = create_session!();
+    let command_type = CommandType::Echo;
+
+    for audit_option in &[AuditOption::On, AuditOption::Off] {
+        yubihsm::put_command_audit_option(&mut session, command_type, *audit_option)
+            .unwrap_or_else(|err| panic!("error setting {:?} audit option: {}", command_type, err));
+
+        let hsm_option = yubihsm::get_command_audit_option(&mut session, command_type)
+            .unwrap_or_else(|err| panic!("error getting {:?} audit option: {}", command_type, err));
+
+        assert_eq!(hsm_option, *audit_option);
+    }
+}
+
+/// Configure the "force audit" option setting
+#[test]
+fn force_audit_option_test() {
+    let mut session = create_session!();
+
+    // Make sure we've consumed the latest log data or else forced auditing
+    // will prevent the tests from completing
+    let audit_logs = yubihsm::get_audit_logs(&mut session)
+        .unwrap_or_else(|err| panic!("error getting audit logs: {}", err));
+
+    if let Some(last_entry) = audit_logs.entries.last() {
+        yubihsm::set_log_index(&mut session, last_entry.item)
+            .unwrap_or_else(|err| panic!("error setting audit log position: {}", err));
+    }
+
+    for audit_option in &[AuditOption::On, AuditOption::Off] {
+        yubihsm::put_force_audit_option(&mut session, *audit_option)
+            .unwrap_or_else(|err| panic!("error setting force option: {}", err));
+
+        let hsm_option = yubihsm::get_force_audit_option(&mut session)
+            .unwrap_or_else(|err| panic!("error getting force option: {}", err));
+
+        assert_eq!(hsm_option, *audit_option);
+    }
+}

--- a/tests/commands/reset.rs
+++ b/tests/commands/reset.rs
@@ -1,0 +1,8 @@
+use yubihsm;
+
+/// Reset the YubiHSM2 to a factory default state
+#[test]
+fn reset_test() {
+    let session = create_session!();
+    yubihsm::reset(session).unwrap();
+}

--- a/tests/commands/sign_ecdsa.rs
+++ b/tests/commands/sign_ecdsa.rs
@@ -1,0 +1,37 @@
+use ring;
+use untrusted;
+use yubihsm::{self, AsymmetricAlgorithm, Capability};
+
+use {generate_asymmetric_key, TEST_KEY_ID, TEST_MESSAGE};
+
+/// Test ECDSA signatures (using NIST P-256)
+#[test]
+fn generated_nistp256_key_test() {
+    let mut session = create_session!();
+
+    generate_asymmetric_key(
+        &mut session,
+        AsymmetricAlgorithm::EC_P256,
+        Capability::ASYMMETRIC_SIGN_ECDSA,
+    );
+
+    let pubkey_response = yubihsm::get_pubkey(&mut session, TEST_KEY_ID)
+        .unwrap_or_else(|err| panic!("error getting public key: {}", err));
+
+    assert_eq!(pubkey_response.algorithm, AsymmetricAlgorithm::EC_P256);
+    assert_eq!(pubkey_response.bytes.len(), 64);
+
+    let mut pubkey = [0u8; 65];
+    pubkey[0] = 0x04; // DER OCTET STRING tag
+    pubkey[1..].copy_from_slice(pubkey_response.bytes.as_slice());
+
+    let signature = yubihsm::sign_ecdsa_sha256(&mut session, TEST_KEY_ID, TEST_MESSAGE)
+        .unwrap_or_else(|err| panic!("error performing ECDSA signature: {}", err));
+
+    ring::signature::verify(
+        &ring::signature::ECDSA_P256_SHA256_ASN1,
+        untrusted::Input::from(&pubkey),
+        untrusted::Input::from(TEST_MESSAGE),
+        untrusted::Input::from(signature.as_ref()),
+    ).unwrap();
+}

--- a/tests/commands/sign_eddsa.rs
+++ b/tests/commands/sign_eddsa.rs
@@ -1,0 +1,59 @@
+use ring;
+use untrusted;
+use yubihsm::{self, AsymmetricAlgorithm, Capability};
+
+use test_vectors::ED25519_TEST_VECTORS;
+use {generate_asymmetric_key, put_asymmetric_key, TEST_KEY_ID, TEST_MESSAGE};
+
+/// Test Ed25519 against RFC 8032 test vectors
+#[test]
+fn test_vectors() {
+    let mut session = create_session!();
+
+    for vector in ED25519_TEST_VECTORS {
+        put_asymmetric_key(
+            &mut session,
+            AsymmetricAlgorithm::EC_ED25519,
+            Capability::ASYMMETRIC_SIGN_EDDSA,
+            vector.sk,
+        );
+
+        let pubkey_response = yubihsm::get_pubkey(&mut session, TEST_KEY_ID)
+            .unwrap_or_else(|err| panic!("error getting public key: {}", err));
+
+        assert_eq!(pubkey_response.algorithm, AsymmetricAlgorithm::EC_ED25519);
+        assert_eq!(pubkey_response.bytes, vector.pk);
+
+        let signature = yubihsm::sign_ed25519(&mut session, TEST_KEY_ID, vector.msg)
+            .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
+
+        assert_eq!(signature.as_ref(), vector.sig);
+    }
+}
+
+/// Test Ed25519 signing using a randomly generated HSM key
+#[test]
+fn generated_key_test() {
+    let mut session = create_session!();
+
+    generate_asymmetric_key(
+        &mut session,
+        AsymmetricAlgorithm::EC_ED25519,
+        Capability::ASYMMETRIC_SIGN_EDDSA,
+    );
+
+    let pubkey = yubihsm::get_pubkey(&mut session, TEST_KEY_ID)
+        .unwrap_or_else(|err| panic!("error getting public key: {}", err));
+
+    assert_eq!(pubkey.algorithm, AsymmetricAlgorithm::EC_ED25519);
+
+    let signature = yubihsm::sign_ed25519(&mut session, TEST_KEY_ID, TEST_MESSAGE)
+        .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
+
+    ring::signature::verify(
+        &ring::signature::ED25519,
+        untrusted::Input::from(pubkey.bytes.as_ref()),
+        untrusted::Input::from(TEST_MESSAGE),
+        untrusted::Input::from(signature.as_ref()),
+    ).unwrap();
+}

--- a/tests/commands/storage_status.rs
+++ b/tests/commands/storage_status.rs
@@ -1,0 +1,15 @@
+use yubihsm;
+
+/// Get stats about currently free storage
+#[test]
+fn storage_status_test() {
+    let mut session = create_session!();
+
+    let response = yubihsm::storage_status(&mut session)
+        .unwrap_or_else(|err| panic!("error getting storage status: {}", err));
+
+    // TODO: these will probably have to change if Yubico releases new models
+    assert_eq!(response.total_records, 256);
+    assert_eq!(response.total_pages, 1024);
+    assert_eq!(response.page_size, 126);
+}

--- a/tests/commands/verify_hmac.rs
+++ b/tests/commands/verify_hmac.rs
@@ -1,0 +1,40 @@
+use yubihsm::{self, Capability, HMACAlgorithm, ObjectType};
+
+use test_vectors::HMAC_SHA256_TEST_VECTORS;
+use {clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
+
+/// Test HMAC against RFC 4231 test vectors
+#[test]
+fn hmac_test_vectors() {
+    let mut session = create_session!();
+    let algorithm = HMACAlgorithm::HMAC_SHA256;
+    let capabilities = Capability::HMAC_DATA | Capability::HMAC_VERIFY;
+
+    for vector in HMAC_SHA256_TEST_VECTORS {
+        clear_test_key_slot(&mut session, ObjectType::HMACKey);
+
+        let key_id = yubihsm::put_hmac_key(
+            &mut session,
+            TEST_KEY_ID,
+            TEST_KEY_LABEL.into(),
+            TEST_DOMAINS,
+            capabilities,
+            algorithm,
+            vector.key,
+        ).unwrap_or_else(|err| panic!("error putting HMAC key: {}", err));
+
+        assert_eq!(key_id, TEST_KEY_ID);
+
+        let tag = yubihsm::hmac(&mut session, TEST_KEY_ID, vector.msg)
+            .unwrap_or_else(|err| panic!("error computing HMAC of data: {}", err));
+
+        assert_eq!(tag.as_ref(), vector.tag);
+
+        assert!(yubihsm::verify_hmac(&mut session, TEST_KEY_ID, vector.msg, vector.tag).is_ok());
+
+        let mut bad_tag = Vec::from(vector.tag);
+        bad_tag[0] ^= 1;
+
+        assert!(yubihsm::verify_hmac(&mut session, TEST_KEY_ID, vector.msg, bad_tag).is_err());
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,15 +1,54 @@
-/// Integration tests (using live YubiHSM2 or MockHSM)
+//! Integration tests (using live YubiHSM2 or MockHSM)
 
 #[cfg(not(feature = "mockhsm"))]
 #[macro_use]
 extern crate lazy_static;
+extern crate ring;
 extern crate sha2;
+extern crate untrusted;
 extern crate yubihsm;
-use yubihsm::{
-    credentials::DEFAULT_AUTH_KEY_ID, AsymmetricAlgorithm, AuditOption, AuthAlgorithm, AuthKey,
-    Capability, CommandType, Domain, HMACAlgorithm, ObjectId, ObjectOrigin, ObjectType,
-    OpaqueAlgorithm, Session, WrapAlgorithm,
-};
+use yubihsm::{AsymmetricAlgorithm, Capability, Domain, ObjectId, ObjectType, Session};
+
+/// Perform a live integration test against yubihsm-connector and a real `YubiHSM2`
+#[cfg(not(feature = "mockhsm"))]
+macro_rules! create_session {
+    () => {
+        $crate::SESSION.lock().unwrap()
+    };
+}
+
+/// Perform an integration test against the MockHSM (useful for CI)
+#[cfg(feature = "mockhsm")]
+macro_rules! create_session {
+    () => {
+        $crate::TestSession::create(::yubihsm::mockhsm::MockHSM::new(), Default::default(), true)
+            .unwrap()
+    };
+}
+
+#[cfg(not(any(feature = "usb", feature = "mockhsm")))]
+lazy_static! {
+    static ref SESSION: ::std::sync::Mutex<TestSession> = {
+        let session = Session::create(Default::default(), Default::default(), true)
+            .unwrap_or_else(|err| panic!("{}", err));
+        ::std::sync::Mutex::new(session)
+    };
+}
+
+#[cfg(all(feature = "usb", not(feature = "mockhsm")))]
+lazy_static! {
+    static ref SESSION: ::std::sync::Mutex<TestSession> = {
+        let session = Session::create(Default::default(), Default::default(), true)
+            .unwrap_or_else(|err| panic!("{}", err));
+        ::std::sync::Mutex::new(session)
+    };
+}
+
+/// Integration tests for individual YubiHSM2 commands
+pub mod commands;
+
+/// Cryptographic test vectors taken from standards documents
+mod test_vectors;
 
 #[cfg(not(any(feature = "usb", feature = "mockhsm")))]
 use yubihsm::HttpAdapter;
@@ -17,17 +56,17 @@ use yubihsm::HttpAdapter;
 #[cfg(all(feature = "usb", not(feature = "mockhsm")))]
 use yubihsm::UsbAdapter;
 
-#[cfg(all(not(feature = "usb"), feature = "mockhsm"))]
-use yubihsm::mockhsm::{MockAdapter, MockHSM};
+#[cfg(feature = "mockhsm")]
+use yubihsm::mockhsm::MockAdapter;
 
-#[cfg(feature = "ring")]
-extern crate ring;
-#[cfg(feature = "ring")]
-extern crate untrusted;
+#[cfg(not(any(feature = "usb", feature = "mockhsm")))]
+type TestSession = Session<HttpAdapter>;
 
-/// Cryptographic test vectors taken from standards documents
-mod test_vectors;
-use test_vectors::*;
+#[cfg(all(feature = "usb", not(feature = "mockhsm")))]
+type TestSession = Session<UsbAdapter>;
+
+#[cfg(feature = "mockhsm")]
+type TestSession = Session<MockAdapter>;
 
 /// Key ID to use for testing keygen/signing
 const TEST_KEY_ID: ObjectId = 100;
@@ -53,51 +92,12 @@ const TEST_MESSAGE: &[u8] = b"The YubiHSM2 is a simple, affordable, and secure H
 /// Size of a NIST P-256 public key
 pub const EC_P256_PUBLIC_KEY_SIZE: usize = 64;
 
-#[cfg(not(any(feature = "usb", feature = "mockhsm")))]
-type TestSession = Session<HttpAdapter>;
-
-#[cfg(all(feature = "usb", not(feature = "mockhsm")))]
-type TestSession = Session<UsbAdapter>;
-
-#[cfg(all(not(feature = "usb"), feature = "mockhsm"))]
-type TestSession = Session<MockAdapter>;
-
-#[cfg(not(any(feature = "usb", feature = "mockhsm")))]
-lazy_static! {
-    static ref SESSION: ::std::sync::Mutex<TestSession> = {
-        let session = Session::create(Default::default(), Default::default(), true)
-            .unwrap_or_else(|err| panic!("{}", err));
-        ::std::sync::Mutex::new(session)
-    };
-}
-
-#[cfg(all(feature = "usb", not(feature = "mockhsm")))]
-lazy_static! {
-    static ref SESSION: ::std::sync::Mutex<TestSession> = {
-        let session = Session::create(Default::default(), Default::default(), true)
-            .unwrap_or_else(|err| panic!("{}", err));
-        ::std::sync::Mutex::new(session)
-    };
-}
-
-/// Perform a live integration test against yubihsm-connector and a real `YubiHSM2`
-#[cfg(not(feature = "mockhsm"))]
-macro_rules! create_session {
-    () => {
-        SESSION.lock().unwrap()
-    };
-}
-
-/// Perform an integration test against the MockHSM (useful for CI)
-#[cfg(feature = "mockhsm")]
-macro_rules! create_session {
-    () => {
-        TestSession::create(MockHSM::new(), Default::default(), true).unwrap()
-    };
-}
+//
+// Helper Functions
+//
 
 /// Delete the key in the test key slot (if it exists, otherwise do nothing)
-fn clear_test_key_slot(session: &mut TestSession, object_type: ObjectType) {
+pub fn clear_test_key_slot(session: &mut TestSession, object_type: ObjectType) {
     // Delete the key in TEST_KEY_ID slot it exists (we use it for testing)
     // Ignore errors since the object may not exist yet
     let _ = yubihsm::delete_object(session, TEST_KEY_ID, object_type);
@@ -107,7 +107,7 @@ fn clear_test_key_slot(session: &mut TestSession, object_type: ObjectType) {
 }
 
 /// Create a public key for use in a test
-fn generate_asymmetric_key(
+pub fn generate_asymmetric_key(
     session: &mut TestSession,
     algorithm: AsymmetricAlgorithm,
     capabilities: Capability,
@@ -127,7 +127,7 @@ fn generate_asymmetric_key(
 }
 
 /// Put an asymmetric private key into the HSM
-fn put_asymmetric_key<T: Into<Vec<u8>>>(
+pub fn put_asymmetric_key<T: Into<Vec<u8>>>(
     session: &mut TestSession,
     algorithm: AsymmetricAlgorithm,
     capabilities: Capability,
@@ -146,619 +146,4 @@ fn put_asymmetric_key<T: Into<Vec<u8>>>(
     ).unwrap_or_else(|err| panic!("error putting asymmetric key: {}", err));
 
     assert_eq!(key_id, TEST_KEY_ID);
-}
-
-/// Generate an attestation about a key in the HSM
-#[cfg(not(feature = "mockhsm"))]
-#[test]
-fn attest_asymmetric_test() {
-    let mut session = create_session!();
-
-    generate_asymmetric_key(
-        &mut session,
-        AsymmetricAlgorithm::EC_P256,
-        Capability::ASYMMETRIC_SIGN_ECDSA,
-    );
-
-    let certificate = yubihsm::attest_asymmetric(&mut session, TEST_KEY_ID, None)
-        .unwrap_or_else(|err| panic!("error getting attestation certificate: {}", err));
-
-    // TODO: more tests, e.g. test that the certificate validates
-    assert!(certificate.len() > EC_P256_PUBLIC_KEY_SIZE);
-}
-
-/// Blink the LED on the YubiHSM for 2 seconds
-#[test]
-fn blink_test() {
-    let mut session = create_session!();
-    yubihsm::blink(&mut session, 2).unwrap();
-}
-
-/// Delete an object in the YubiHSM2
-#[test]
-fn delete_object_test() {
-    let mut session = create_session!();
-
-    generate_asymmetric_key(
-        &mut session,
-        AsymmetricAlgorithm::EC_ED25519,
-        Capability::ASYMMETRIC_SIGN_EDDSA,
-    );
-
-    // The first request to delete should succeed because the object exists
-    assert!(yubihsm::delete_object(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey).is_ok());
-
-    // The second request to delete should fail because it's already deleted
-    assert!(yubihsm::delete_object(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey).is_err());
-}
-
-/// Get device information
-#[test]
-fn device_info_test() {
-    let mut session = create_session!();
-
-    let device_info = yubihsm::device_info(&mut session)
-        .unwrap_or_else(|err| panic!("error getting device info: {}", err));
-
-    assert_eq!(device_info.major_version, 2);
-    assert_eq!(device_info.minor_version, 0);
-    assert_eq!(device_info.build_version, 0);
-}
-
-/// Send a simple echo request
-#[test]
-fn echo_test() {
-    let mut session = create_session!();
-
-    let echo_response = yubihsm::echo(&mut session, TEST_MESSAGE)
-        .unwrap_or_else(|err| panic!("error sending echo: {}", err));
-
-    assert_eq!(TEST_MESSAGE, echo_response.as_slice());
-}
-
-/// Generate an Ed25519 key
-#[test]
-fn generate_ed25519_key_test() {
-    let mut session = create_session!();
-
-    let algorithm = AsymmetricAlgorithm::EC_ED25519;
-    let capabilities = Capability::ASYMMETRIC_SIGN_EDDSA;
-
-    generate_asymmetric_key(&mut session, algorithm, capabilities);
-
-    let object_info =
-        yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey)
-            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(object_info.capabilities, capabilities);
-    assert_eq!(object_info.object_id, TEST_KEY_ID);
-    assert_eq!(object_info.domains, TEST_DOMAINS);
-    assert_eq!(object_info.object_type, ObjectType::AsymmetricKey);
-    assert_eq!(object_info.algorithm, algorithm.into());
-    assert_eq!(object_info.origin, ObjectOrigin::Generated);
-    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
-}
-
-/// Generate an Ed25519 key
-#[test]
-fn generate_hmac_key_test() {
-    let mut session = create_session!();
-
-    let algorithm = HMACAlgorithm::HMAC_SHA256;
-    let capabilities = Capability::HMAC_DATA | Capability::HMAC_VERIFY;
-
-    clear_test_key_slot(&mut session, ObjectType::HMACKey);
-
-    let key_id = yubihsm::generate_hmac_key(
-        &mut session,
-        TEST_KEY_ID,
-        TEST_KEY_LABEL.into(),
-        TEST_DOMAINS,
-        capabilities,
-        algorithm,
-    ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
-
-    assert_eq!(key_id, TEST_KEY_ID);
-
-    let object_info = yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::HMACKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(object_info.capabilities, capabilities);
-    assert_eq!(object_info.object_id, TEST_KEY_ID);
-    assert_eq!(object_info.domains, TEST_DOMAINS);
-    assert_eq!(object_info.object_type, ObjectType::HMACKey);
-    assert_eq!(object_info.algorithm, algorithm.into());
-    assert_eq!(object_info.origin, ObjectOrigin::Generated);
-    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
-}
-
-/// Generate a NIST P-256 key
-#[test]
-fn generate_secp256r1_key_test() {
-    let mut session = create_session!();
-    let algorithm = AsymmetricAlgorithm::EC_P256;
-    let capabilities = Capability::ASYMMETRIC_SIGN_EDDSA;
-
-    generate_asymmetric_key(&mut session, algorithm, capabilities);
-
-    let object_info =
-        yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey)
-            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(object_info.capabilities, capabilities);
-    assert_eq!(object_info.object_id, TEST_KEY_ID);
-    assert_eq!(object_info.domains, TEST_DOMAINS);
-    assert_eq!(object_info.object_type, ObjectType::AsymmetricKey);
-    assert_eq!(object_info.algorithm, algorithm.into());
-    assert_eq!(object_info.origin, ObjectOrigin::Generated);
-    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
-}
-
-/// Generate an AES-CCM key wrapping key
-#[test]
-fn generate_wrap_key_test() {
-    let mut session = create_session!();
-
-    let algorithm = WrapAlgorithm::AES256_CCM_WRAP;
-    let capabilities = Capability::EXPORT_WRAPPED
-        | Capability::IMPORT_WRAPPED
-        | Capability::UNWRAP_DATA
-        | Capability::WRAP_DATA;
-    let delegated_capabilities = Capability::all();
-
-    clear_test_key_slot(&mut session, ObjectType::WrapKey);
-
-    let key_id = yubihsm::generate_wrap_key(
-        &mut session,
-        TEST_KEY_ID,
-        TEST_KEY_LABEL.into(),
-        TEST_DOMAINS,
-        capabilities,
-        delegated_capabilities,
-        algorithm,
-    ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
-
-    assert_eq!(key_id, TEST_KEY_ID);
-
-    let object_info = yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::WrapKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(object_info.capabilities, capabilities);
-    assert_eq!(object_info.object_id, TEST_KEY_ID);
-    assert_eq!(object_info.domains, TEST_DOMAINS);
-    assert_eq!(object_info.object_type, ObjectType::WrapKey);
-    assert_eq!(object_info.algorithm, algorithm.into());
-    assert_eq!(object_info.origin, ObjectOrigin::Generated);
-    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
-}
-
-/// Get audit log
-#[test]
-fn get_logs_test() {
-    let mut session = create_session!();
-
-    // TODO: test audit logging functionality
-    yubihsm::get_audit_logs(&mut session)
-        .unwrap_or_else(|err| panic!("error getting logs: {}", err));
-}
-
-/// Get object info on default auth key
-#[test]
-fn get_object_info_default_authkey() {
-    let mut session = create_session!();
-
-    let object_info =
-        yubihsm::get_object_info(&mut session, DEFAULT_AUTH_KEY_ID, ObjectType::AuthKey)
-            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(object_info.capabilities, Capability::all());
-    assert_eq!(object_info.object_id, DEFAULT_AUTH_KEY_ID);
-    assert_eq!(object_info.domains, Domain::all());
-    assert_eq!(object_info.object_type, ObjectType::AuthKey);
-    assert_eq!(object_info.algorithm, AuthAlgorithm::YUBICO_AES_AUTH.into());
-    assert_eq!(object_info.origin, ObjectOrigin::Imported);
-    assert_eq!(
-        &object_info.label.to_string().unwrap(),
-        DEFAULT_AUTH_KEY_LABEL
-    );
-}
-
-/// Get the auditing options for all commands
-#[test]
-fn get_command_audit_options_test() {
-    let mut session = create_session!();
-
-    let results = yubihsm::get_all_command_audit_options(&mut session)
-        .unwrap_or_else(|err| panic!("error getting force option: {}", err));
-
-    assert!(results.len() > 1);
-}
-
-/// Get the "force audit" option setting
-#[test]
-fn get_force_audit_option_test() {
-    let mut session = create_session!();
-
-    yubihsm::get_force_audit_option(&mut session)
-        .unwrap_or_else(|err| panic!("error getting force option: {}", err));
-}
-
-/// Get random bytes
-#[test]
-fn get_pseudo_random() {
-    let mut session = create_session!();
-
-    let bytes = yubihsm::get_pseudo_random(&mut session, 32)
-        .unwrap_or_else(|err| panic!("error getting random data: {}", err));
-
-    assert_eq!(32, bytes.len());
-}
-
-/// Test HMAC against RFC 4231 test vectors
-#[test]
-fn hmac_test_vectors() {
-    let mut session = create_session!();
-    let algorithm = HMACAlgorithm::HMAC_SHA256;
-    let capabilities = Capability::HMAC_DATA | Capability::HMAC_VERIFY;
-
-    for vector in HMAC_SHA256_TEST_VECTORS {
-        clear_test_key_slot(&mut session, ObjectType::HMACKey);
-
-        let key_id = yubihsm::put_hmac_key(
-            &mut session,
-            TEST_KEY_ID,
-            TEST_KEY_LABEL.into(),
-            TEST_DOMAINS,
-            capabilities,
-            algorithm,
-            vector.key,
-        ).unwrap_or_else(|err| panic!("error putting HMAC key: {}", err));
-
-        assert_eq!(key_id, TEST_KEY_ID);
-
-        let tag = yubihsm::hmac(&mut session, TEST_KEY_ID, vector.msg)
-            .unwrap_or_else(|err| panic!("error computing HMAC of data: {}", err));
-
-        assert_eq!(tag.as_ref(), vector.tag);
-
-        assert!(yubihsm::verify_hmac(&mut session, TEST_KEY_ID, vector.msg, vector.tag).is_ok());
-
-        let mut bad_tag = Vec::from(vector.tag);
-        bad_tag[0] ^= 1;
-
-        assert!(yubihsm::verify_hmac(&mut session, TEST_KEY_ID, vector.msg, bad_tag).is_err());
-    }
-}
-
-/// List the objects in the YubiHSM2
-#[test]
-fn list_objects_test() {
-    let mut session = create_session!();
-
-    generate_asymmetric_key(
-        &mut session,
-        AsymmetricAlgorithm::EC_ED25519,
-        Capability::ASYMMETRIC_SIGN_EDDSA,
-    );
-
-    let objects = yubihsm::list_objects(&mut session)
-        .unwrap_or_else(|err| panic!("error listing objects: {}", err));
-
-    // Look for the asymmetric key we just generated
-    assert!(
-        objects
-            .iter()
-            .find(|i| i.object_id == TEST_KEY_ID && i.object_type == ObjectType::AsymmetricKey)
-            .is_some()
-    );
-}
-
-/// Put an opaquae object and read it back
-#[test]
-fn opaque_object_test() {
-    let mut session = create_session!();
-
-    clear_test_key_slot(&mut session, ObjectType::Opaque);
-
-    let object_id = yubihsm::put_opaque(
-        &mut session,
-        TEST_KEY_ID,
-        TEST_KEY_LABEL.into(),
-        TEST_DOMAINS,
-        Capability::default(),
-        OpaqueAlgorithm::OPAQUE_DATA,
-        TEST_MESSAGE,
-    ).unwrap_or_else(|err| panic!("error putting opaque object: {}", err));
-
-    assert_eq!(object_id, TEST_KEY_ID);
-
-    let opaque_data = yubihsm::get_opaque(&mut session, TEST_KEY_ID)
-        .unwrap_or_else(|err| panic!("error getting opaque object: {}", err));
-
-    assert_eq!(opaque_data, TEST_MESSAGE);
-}
-
-/// Put an Ed25519 key
-#[test]
-fn put_asymmetric_key_test() {
-    let mut session = create_session!();
-    let algorithm = AsymmetricAlgorithm::EC_ED25519;
-    let capabilities = Capability::ASYMMETRIC_SIGN_EDDSA;
-    let example_private_key = ED25519_TEST_VECTORS[0].sk;
-
-    put_asymmetric_key(&mut session, algorithm, capabilities, example_private_key);
-
-    let object_info =
-        yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AsymmetricKey)
-            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(object_info.capabilities, capabilities);
-    assert_eq!(object_info.object_id, TEST_KEY_ID);
-    assert_eq!(object_info.domains, TEST_DOMAINS);
-    assert_eq!(object_info.object_type, ObjectType::AsymmetricKey);
-    assert_eq!(object_info.algorithm, algorithm.into());
-    assert_eq!(object_info.origin, ObjectOrigin::Imported);
-    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
-}
-
-/// Put a new authentication key into the `YubiHSM`
-#[test]
-fn put_auth_key() {
-    let mut session = create_session!();
-    let algorithm = AuthAlgorithm::YUBICO_AES_AUTH;
-    let capabilities = Capability::all();
-    let delegated_capabilities = Capability::all();
-
-    clear_test_key_slot(&mut session, ObjectType::AuthKey);
-
-    let new_auth_key = AuthKey::derive_from_password(TEST_MESSAGE);
-
-    let key_id = yubihsm::put_auth_key(
-        &mut session,
-        TEST_KEY_ID,
-        TEST_KEY_LABEL.into(),
-        TEST_DOMAINS,
-        capabilities,
-        delegated_capabilities,
-        algorithm,
-        new_auth_key,
-    ).unwrap_or_else(|err| panic!("error putting auth key: {}", err));
-
-    assert_eq!(key_id, TEST_KEY_ID);
-
-    let object_info = yubihsm::get_object_info(&mut session, TEST_KEY_ID, ObjectType::AuthKey)
-        .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(object_info.capabilities, capabilities);
-    assert_eq!(object_info.object_id, TEST_KEY_ID);
-    assert_eq!(object_info.domains, TEST_DOMAINS);
-    assert_eq!(object_info.object_type, ObjectType::AuthKey);
-    assert_eq!(object_info.algorithm, algorithm.into());
-    assert_eq!(object_info.origin, ObjectOrigin::Imported);
-    assert_eq!(&object_info.label.to_string().unwrap(), TEST_KEY_LABEL);
-}
-
-/// Set the auditing options for a particular command
-#[test]
-fn put_command_audit_options_test() {
-    let mut session = create_session!();
-    let command_type = CommandType::Echo;
-
-    for audit_option in &[AuditOption::On, AuditOption::Off] {
-        yubihsm::put_command_audit_option(&mut session, command_type, *audit_option)
-            .unwrap_or_else(|err| panic!("error setting {:?} audit option: {}", command_type, err));
-
-        let hsm_option = yubihsm::get_command_audit_option(&mut session, command_type)
-            .unwrap_or_else(|err| panic!("error getting {:?} audit option: {}", command_type, err));
-
-        assert_eq!(hsm_option, *audit_option);
-    }
-}
-
-/// Configure the "force audit" option setting
-#[test]
-fn put_force_audit_option_test() {
-    let mut session = create_session!();
-
-    // Make sure we've consumed the latest log data or else forced auditing
-    // will prevent the tests from completing
-    let audit_logs = yubihsm::get_audit_logs(&mut session)
-        .unwrap_or_else(|err| panic!("error getting audit logs: {}", err));
-
-    if let Some(last_entry) = audit_logs.entries.last() {
-        yubihsm::set_log_index(&mut session, last_entry.item)
-            .unwrap_or_else(|err| panic!("error setting audit log position: {}", err));
-    }
-
-    for audit_option in &[AuditOption::On, AuditOption::Off] {
-        yubihsm::put_force_audit_option(&mut session, *audit_option)
-            .unwrap_or_else(|err| panic!("error setting force option: {}", err));
-
-        let hsm_option = yubihsm::get_force_audit_option(&mut session)
-            .unwrap_or_else(|err| panic!("error getting force option: {}", err));
-
-        assert_eq!(hsm_option, *audit_option);
-    }
-}
-
-/// Reset the YubiHSM2 to a factory default state
-#[cfg(feature = "mockhsm")]
-#[test]
-fn reset_test() {
-    let session = create_session!();
-    yubihsm::reset(session).unwrap();
-}
-
-/// Test ECDSA signatures (using NIST P-256)
-#[cfg(feature = "ring")]
-#[test]
-fn sign_ecdsa_secp256r1_with_generated_key_test() {
-    let mut session = create_session!();
-
-    generate_asymmetric_key(
-        &mut session,
-        AsymmetricAlgorithm::EC_P256,
-        Capability::ASYMMETRIC_SIGN_ECDSA,
-    );
-
-    let pubkey_response = yubihsm::get_pubkey(&mut session, TEST_KEY_ID)
-        .unwrap_or_else(|err| panic!("error getting public key: {}", err));
-
-    assert_eq!(pubkey_response.algorithm, AsymmetricAlgorithm::EC_P256);
-    assert_eq!(pubkey_response.bytes.len(), 64);
-
-    let mut pubkey = [0u8; 65];
-    pubkey[0] = 0x04; // DER OCTET STRING tag
-    pubkey[1..].copy_from_slice(pubkey_response.bytes.as_slice());
-
-    let signature = yubihsm::sign_ecdsa_sha256(&mut session, TEST_KEY_ID, TEST_MESSAGE)
-        .unwrap_or_else(|err| panic!("error performing ECDSA signature: {}", err));
-
-    ring::signature::verify(
-        &ring::signature::ECDSA_P256_SHA256_ASN1,
-        untrusted::Input::from(&pubkey),
-        untrusted::Input::from(TEST_MESSAGE),
-        untrusted::Input::from(signature.as_ref()),
-    ).unwrap();
-}
-
-/// Test Ed25519 against RFC 8032 test vectors
-#[test]
-fn sign_ed25519_test_vectors() {
-    let mut session = create_session!();
-
-    for vector in ED25519_TEST_VECTORS {
-        put_asymmetric_key(
-            &mut session,
-            AsymmetricAlgorithm::EC_ED25519,
-            Capability::ASYMMETRIC_SIGN_EDDSA,
-            vector.sk,
-        );
-
-        let pubkey_response = yubihsm::get_pubkey(&mut session, TEST_KEY_ID)
-            .unwrap_or_else(|err| panic!("error getting public key: {}", err));
-
-        assert_eq!(pubkey_response.algorithm, AsymmetricAlgorithm::EC_ED25519);
-        assert_eq!(pubkey_response.bytes, vector.pk);
-
-        let signature = yubihsm::sign_ed25519(&mut session, TEST_KEY_ID, vector.msg)
-            .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
-
-        assert_eq!(signature.as_ref(), vector.sig);
-    }
-}
-
-/// Test Ed25519 signing using a randomly generated HSM key
-#[cfg(feature = "ring")]
-#[test]
-fn sign_ed25519_with_generated_key_test() {
-    let mut session = create_session!();
-
-    generate_asymmetric_key(
-        &mut session,
-        AsymmetricAlgorithm::EC_ED25519,
-        Capability::ASYMMETRIC_SIGN_EDDSA,
-    );
-
-    let pubkey = yubihsm::get_pubkey(&mut session, TEST_KEY_ID)
-        .unwrap_or_else(|err| panic!("error getting public key: {}", err));
-
-    assert_eq!(pubkey.algorithm, AsymmetricAlgorithm::EC_ED25519);
-
-    let signature = yubihsm::sign_ed25519(&mut session, TEST_KEY_ID, TEST_MESSAGE)
-        .unwrap_or_else(|err| panic!("error performing Ed25519 signature: {}", err));
-
-    ring::signature::verify(
-        &ring::signature::ED25519,
-        untrusted::Input::from(pubkey.bytes.as_ref()),
-        untrusted::Input::from(TEST_MESSAGE),
-        untrusted::Input::from(signature.as_ref()),
-    ).unwrap();
-}
-
-/// Get stats about currently free storage
-#[test]
-fn storage_status_test() {
-    let mut session = create_session!();
-
-    let response = yubihsm::storage_status(&mut session)
-        .unwrap_or_else(|err| panic!("error getting storage status: {}", err));
-
-    // TODO: these will probably have to change if Yubico releases new models
-    assert_eq!(response.total_records, 256);
-    assert_eq!(response.total_pages, 1024);
-    assert_eq!(response.page_size, 126);
-}
-
-/// Test wrap key workflow using randomly generated keys
-// TODO: test against RFC 3610 vectors
-#[test]
-fn wrap_key_test() {
-    let mut session = create_session!();
-    let algorithm = WrapAlgorithm::AES128_CCM_WRAP;
-    let capabilities = Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED;
-    let delegated_capabilities = Capability::all();
-
-    clear_test_key_slot(&mut session, ObjectType::WrapKey);
-
-    let key_id = yubihsm::put_wrap_key(
-        &mut session,
-        TEST_KEY_ID,
-        TEST_KEY_LABEL.into(),
-        TEST_DOMAINS,
-        capabilities,
-        delegated_capabilities,
-        algorithm,
-        AESCCM_TEST_VECTORS[0].key,
-    ).unwrap_or_else(|err| panic!("error generating wrap key: {}", err));
-
-    assert_eq!(key_id, TEST_KEY_ID);
-
-    // Create a key to export
-    let exported_key_type = ObjectType::AsymmetricKey;
-    let exported_key_capabilities =
-        Capability::ASYMMETRIC_SIGN_EDDSA | Capability::EXPORT_UNDER_WRAP;
-    let exported_key_algorithm = AsymmetricAlgorithm::EC_ED25519;
-
-    let _ = yubihsm::delete_object(&mut session, TEST_EXPORTED_KEY_ID, exported_key_type);
-    yubihsm::generate_asymmetric_key(
-        &mut session,
-        TEST_EXPORTED_KEY_ID,
-        TEST_EXPORTED_KEY_LABEL.into(),
-        TEST_DOMAINS,
-        exported_key_capabilities,
-        exported_key_algorithm,
-    ).unwrap_or_else(|err| panic!("error generating asymmetric key: {}", err));
-
-    let wrap_data = yubihsm::export_wrapped(
-        &mut session,
-        TEST_KEY_ID,
-        exported_key_type,
-        TEST_EXPORTED_KEY_ID,
-    ).unwrap_or_else(|err| panic!("error exporting key: {}", err));
-
-    // Delete the object from the HSM prior to re-importing it
-    assert!(yubihsm::delete_object(&mut session, TEST_EXPORTED_KEY_ID, exported_key_type).is_ok());
-
-    // Re-import the wrapped key back into the HSM
-    let import_response = yubihsm::import_wrapped(&mut session, TEST_KEY_ID, wrap_data)
-        .unwrap_or_else(|err| panic!("error importing key: {}", err));
-
-    assert_eq!(import_response.object_type, exported_key_type);
-    assert_eq!(import_response.object_id, TEST_EXPORTED_KEY_ID);
-
-    let imported_key_info =
-        yubihsm::get_object_info(&mut session, TEST_EXPORTED_KEY_ID, exported_key_type)
-            .unwrap_or_else(|err| panic!("error getting object info: {}", err));
-
-    assert_eq!(imported_key_info.capabilities, exported_key_capabilities);
-    assert_eq!(imported_key_info.object_id, TEST_EXPORTED_KEY_ID);
-    assert_eq!(imported_key_info.domains, TEST_DOMAINS);
-    assert_eq!(imported_key_info.object_type, exported_key_type);
-    assert_eq!(imported_key_info.algorithm, exported_key_algorithm.into());
-    assert_eq!(imported_key_info.origin, ObjectOrigin::WrappedGenerated);
-    assert_eq!(
-        &imported_key_info.label.to_string().unwrap(),
-        TEST_EXPORTED_KEY_LABEL
-    );
 }


### PR DESCRIPTION
The previous `integration.rs` was a gigantic file full of the entire test suite. It was a bit hard to tell what was going on.

This factors the tests into individual submodules for each command.

Notable is that there is a 1:1 mapping between:

```
tests/commands/*.rs
```

and

```
src/commands/*.rs
```

That is to say, for each test submodule in `tests/commands/*.rs`, there is a corresponding module in `src/commands` whose name maps to the YubiHSM2 command documented here:

<https://developers.yubico.com/YubiHSM2/Commands/>