### PR TITLE
v0.16.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,37 @@
+## [0.16.0] (2018-09-12)
+
+[0.16.0]: https://github.com/tendermint/yubihsm-rs/compare/v0.15.1...v0.16.0
+
+* [#112](https://github.com/tendermint/yubihsm-rs/pull/112)
+  Make 'http' a cargo feature.
+
+* [#111](https://github.com/tendermint/yubihsm-rs/pull/111)
+  Rename `MockHSM` => `MockHsm`; export from crate root.
+
+* [#110](https://github.com/tendermint/yubihsm-rs/pull/110)
+  Factor HSM error handling into `HsmErrorKind`.
+
+* [#109](https://github.com/tendermint/yubihsm-rs/pull/109)
+  Refactor Algorithm and related types.
+  
+* [#107](https://github.com/tendermint/yubihsm-rs/pull/107)
+  Decode detailed HSM errors from responses.
+
+* [#106](https://github.com/tendermint/yubihsm-rs/pull/106)
+  Implement Put Option commands.
+
+* [#101](https://github.com/tendermint/yubihsm-rs/pull/101)
+  Implement Get Option commands.
+
+* [#97](https://github.com/tendermint/yubihsm-rs/pull/97)
+  USB support. Rename `Connector` => `Adapter`.
+
 ## [0.15.1] (2018-08-24)
 
 [0.15.1]: https://github.com/tendermint/yubihsm-rs/compare/v0.15.0...v0.15.1
 
 * [#93](https://github.com/tendermint/yubihsm-rs/pull/93)
-  `http_connector.rs`: Derive Clone on HttpConfig,
+  `http_connector.rs`: Derive Clone on HttpConfig.
 
 ## [0.15.0] (2018-08-19)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "yubihsm"
 description   = "Pure Rust client for YubiHSM2 devices"
-version       = "0.16.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version       = "0.16.0" # Also update html_root_url in lib.rs when bumping this
 license       = "MIT OR Apache-2.0"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/master/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.16.0-alpha3"
+    html_root_url = "https://docs.rs/yubihsm/0.16.0"
 )]
 
 extern crate aes;


### PR DESCRIPTION
[Diff from v0.15.1](https://github.com/tendermint/yubihsm-rs/compare/v0.15.1...v0.16.0)

* #112: Make 'http' a cargo feature.
* #111: Rename `MockHSM` => `MockHsm`; export from crate root.
* #110: Factor HSM error handling into `HsmErrorKind`.
* #109: Refactor Algorithm and related types.
* #107: Decode detailed HSM errors from responses.
* #106: Implement Put Option commands.
* #101: Implement Get Option commands.
* #97: USB support. Rename `Connector` => `Adapter`.