### PR TITLE
.circleci/config.yml: Use iqlusion/rust-ci:20180913.2 Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,23 +3,23 @@ version: 2
 jobs:
   build:
     docker:
-    - image: iqlusion/rust-ci:20180905.2 # bump cache keys when modifying this
+    - image: iqlusion/rust-ci:20180913.2 # bump cache keys when modifying this
 
     steps:
     - checkout
     - restore_cache:
-        key: cache-20180905.2 # bump save_cache key below too
+        key: cache-20180913.2 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
-          cargo +$RUST_NIGHTLY_VERSION fmt --version
-          cargo +$RUST_NIGHTLY_VERSION fmt -- --check
+          cargo fmt --version
+          cargo fmt -- --check
     - run:
         name: clippy
         command: |
-          cargo +$RUST_NIGHTLY_VERSION clippy --version
-          cargo +$RUST_NIGHTLY_VERSION clippy --features=rsa,usb
-          cargo +$RUST_NIGHTLY_VERSION clippy --features=mockhsm
+          cargo clippy --version
+          cargo clippy --features=rsa,usb
+          cargo clippy --features=mockhsm
     - run:
         name: build --no-default-features
         command: |
@@ -80,7 +80,7 @@ jobs:
           cargo audit --version
           cargo audit
     - save_cache:
-        key: cache-20180905.2 # bump restore_cache key above too
+        key: cache-20180913.2 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/src/commands/sign_ecdsa.rs
+++ b/src/commands/sign_ecdsa.rs
@@ -27,11 +27,13 @@ use adapters::Adapter;
 #[cfg(all(feature = "mockhsm", not(feature = "doc")))]
 use mockhsm::MockAdapter;
 use session::{Session, SessionError};
-#[cfg(all(
-    feature = "sha2",
-    any(feature = "http", feature = "usb"),
-    any(feature = "doc", not(feature = "mockhsm"))
-))]
+#[cfg(
+    all(
+        feature = "sha2",
+        any(feature = "http", feature = "usb"),
+        any(feature = "doc", not(feature = "mockhsm"))
+    )
+)]
 use sha2::{Digest, Sha256};
 use {CommandType, ObjectId};
 
@@ -62,11 +64,13 @@ type AdapterType = HttpAdapter;
 type AdapterType = UsbAdapter;
 
 /// Compute an ECDSA signature of the SHA-256 hash of the given data with the given key ID
-#[cfg(all(
-    feature = "sha2",
-    any(feature = "http", feature = "usb"),
-    any(feature = "doc", not(feature = "mockhsm"))
-))]
+#[cfg(
+    all(
+        feature = "sha2",
+        any(feature = "http", feature = "usb"),
+        any(feature = "doc", not(feature = "mockhsm"))
+    )
+)]
 pub fn sign_ecdsa_sha256(
     session: &mut Session<AdapterType>,
     key_id: ObjectId,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,8 +21,11 @@ macro_rules! create_session {
 #[cfg(feature = "mockhsm")]
 macro_rules! create_session {
     () => {
-        $crate::TestSession::create(::yubihsm::mockhsm::MockHsm::new(), Default::default(), true)
-            .unwrap()
+        $crate::TestSession::create(
+            ::yubihsm::mockhsm::MockHsm::new(),
+            Default::default(),
+            true,
+        ).unwrap()
     };
 }
 


### PR DESCRIPTION
Includes Rust 1.29 stable; cargo clippy now stable