### PR TITLE
Add serial_number() method to Session and Adapter trait

### DIFF
--- a/src/adapters/http/adapter.rs
+++ b/src/adapters/http/adapter.rs
@@ -11,8 +11,9 @@ use uuid::Uuid;
 use super::{status::CONNECTOR_STATUS_OK, ConnectorStatus, HttpConfig, ResponseReader, USER_AGENT};
 use adapters::{
     Adapter, AdapterError,
-    AdapterErrorKind::{AddrInvalid, ConnectionFailed},
+    AdapterErrorKind::{AddrInvalid, ConnectionFailed, ResponseError},
 };
+use serial_number::SerialNumber;
 
 /// HTTP(-ish) adapter which supports the minimal parts of the protocol
 /// required to communicate with the yubihsm-connector service.
@@ -65,6 +66,16 @@ impl Adapter for HttpAdapter {
                 &status.message
             );
         }
+    }
+
+    /// Get the serial number for the current YubiHSM2 (if available)
+    fn serial_number(&self) -> Result<SerialNumber, AdapterError> {
+        self.status()?.serial_number.ok_or_else(|| {
+            err!(
+                ResponseError,
+                "no serial available. Launch yubihsm-connector with the --serial option"
+            )
+        })
     }
 
     /// `POST /connector/api` with a given command message

--- a/src/adapters/http/status.rs
+++ b/src/adapters/http/status.rs
@@ -17,7 +17,7 @@ pub struct ConnectorStatus {
 
     /// Serial number of `YubiHSM2` device. Only available if `yubihsm-connector`
     /// has been started with the --serial option
-    pub serial: Option<SerialNumber>,
+    pub serial_number: Option<SerialNumber>,
 
     /// `YubiHSM2` SDK version for `yubihsm-connector`
     pub version: String,
@@ -66,7 +66,7 @@ impl ConnectorStatus {
             .ok_or_else(|| err!(ResponseError, "missing status"))?
             .to_owned();
 
-        let serial = match response_serial {
+        let serial_number = match response_serial {
             Some("*") => None,
             Some(s) => Some(SerialNumber::from_str(s)?),
             None => fail!(ResponseError, "missing serial"),
@@ -83,7 +83,7 @@ impl ConnectorStatus {
 
         Ok(Self {
             message,
-            serial,
+            serial_number,
             version,
             pid,
         })

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -9,6 +9,7 @@ use std::fmt::Debug;
 use uuid::Uuid;
 
 pub use self::error::{AdapterError, AdapterErrorKind};
+use serial_number::SerialNumber;
 
 /// Adapters for communicating with the YubiHSM2
 pub trait Adapter: Sized + Send + Sync {
@@ -20,6 +21,9 @@ pub trait Adapter: Sized + Send + Sync {
 
     /// Are we able to send/receive messages to/from the HSM?
     fn healthcheck(&self) -> Result<(), AdapterError>;
+
+    /// Get the serial number for the current YubiHSM2 (if available)
+    fn serial_number(&self) -> Result<SerialNumber, AdapterError>;
 
     /// Send a command message to the HSM, then read and return the response
     fn send_message(&self, uuid: Uuid, msg: Vec<u8>) -> Result<Vec<u8>, AdapterError>;

--- a/src/adapters/usb/adapter.rs
+++ b/src/adapters/usb/adapter.rs
@@ -84,6 +84,11 @@ impl Adapter for UsbAdapter {
         Ok(())
     }
 
+    /// Get the serial number for the current YubiHSM2 (if available)
+    fn serial_number(&self) -> Result<SerialNumber, AdapterError> {
+        Ok(self.serial_number)
+    }
+
     /// Send a command to the YubiHSM and read its response
     fn send_message(&self, _uuid: Uuid, cmd: Vec<u8>) -> Result<Vec<u8>, AdapterError> {
         let mut handle = self.handle.lock().unwrap();

--- a/src/mockhsm/adapter.rs
+++ b/src/mockhsm/adapter.rs
@@ -1,13 +1,20 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 use uuid::Uuid;
 
 use super::{commands, state::State, MockHsm};
 use adapters::{Adapter, AdapterError, AdapterErrorKind::ConnectionFailed};
 use commands::CommandType;
 use securechannel::CommandMessage;
+use serial_number::SerialNumber;
 
 /// A mocked connection to the MockHsm
 pub struct MockAdapter(Arc<Mutex<State>>);
+
+/// Mock serial number for the MockHsm
+pub const MOCK_SERIAL_NUMBER: &str = "0123456789";
 
 impl Adapter for MockAdapter {
     type Config = MockHsm;
@@ -20,6 +27,11 @@ impl Adapter for MockAdapter {
     /// Rust never sleeps
     fn healthcheck(&self) -> Result<(), AdapterError> {
         Ok(())
+    }
+
+    /// Get the serial number for the current YubiHSM2 (if available)
+    fn serial_number(&self) -> Result<SerialNumber, AdapterError> {
+        Ok(SerialNumber::from_str(MOCK_SERIAL_NUMBER).unwrap())
     }
 
     /// Send a message to the MockHsm

--- a/src/serial_number.rs
+++ b/src/serial_number.rs
@@ -1,4 +1,7 @@
-use std::str;
+use std::{
+    fmt::{self, Display},
+    str::{self, FromStr},
+};
 
 use adapters::{AdapterError, AdapterErrorKind::AddrInvalid};
 
@@ -22,7 +25,13 @@ impl AsRef<str> for SerialNumber {
     }
 }
 
-impl str::FromStr for SerialNumber {
+impl Display for SerialNumber {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for SerialNumber {
     type Err = AdapterError;
 
     fn from_str(s: &str) -> Result<SerialNumber, AdapterError> {

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -37,30 +37,6 @@ pub enum SessionErrorKind {
     /// Error response from HSM we can't further specify
     #[fail(display = "HSM error")]
     ResponseError,
-
-    /// Session with HSM failed
-    #[fail(display = "session failed")]
-    SessionFailed,
-
-    /// Session with HSM invalid
-    #[fail(display = "invalid session")]
-    SessionInvalid,
-
-    /// HSM exceeded maximum number of sessions (16)
-    #[fail(display = "HSM sessions full (max 16)")]
-    SessionsFull,
-
-    /// HSM storage failure
-    #[fail(display = "HSM storage failure")]
-    StorageFailed,
-
-    /// Session with the YubiHSM2 timed out
-    #[fail(display = "session timeout")]
-    TimeoutError,
-
-    /// Length incorrect for operation
-    #[fail(display = "wrong length")]
-    WrongLength,
 }
 
 impl From<AdapterError> for SessionError {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -11,6 +11,7 @@ use adapters::Adapter;
 use commands::{close_session::CloseSessionCommand, Command};
 use credentials::Credentials;
 use securechannel::SessionId;
+use serial_number::SerialNumber;
 
 /// Write consistent `debug!(...) lines for sessions
 macro_rules! session_debug {
@@ -166,6 +167,11 @@ impl<A: Adapter> Session<A> {
     /// Borrow the adapter for this session (if available)
     pub fn adapter(&mut self) -> Result<&A, SessionError> {
         Ok(self.connection()?.adapter())
+    }
+
+    /// Get the serial number of the underlying HSM, if it's available
+    pub fn serial_number(&mut self) -> Result<SerialNumber, SessionError> {
+        Ok(self.adapter()?.serial_number()?)
     }
 
     /// Encrypt a command, send it to the HSM, then read and decrypt the response

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -95,6 +95,16 @@ const TEST_MESSAGE: &[u8] = b"The YubiHSM2 is a simple, affordable, and secure H
 /// Size of a NIST P-256 public key
 pub const EC_P256_PUBLIC_KEY_SIZE: usize = 64;
 
+/// Ensure we can read the YubiHSM2's serial number
+#[test]
+fn get_yubihsm_serial_number() {
+    let mut session = create_session!();
+    #[allow(unused_variables)]
+    let serial_result = session.serial_number();
+    #[cfg(any(feature = "usb", feature = "mockhsm"))]
+    assert!(serial_result.is_ok());
+}
+
 //
 // Helper Functions
 //


### PR DESCRIPTION
Support for getting the serial number of the current YubiHSM2 easily