### PR TITLE
Expose more information about USB devices

### DIFF
--- a/src/adapters/http/macros.rs
+++ b/src/adapters/http/macros.rs
@@ -1,0 +1,9 @@
+/// Write consistent `debug!(...) lines for adapters
+macro_rules! http_debug {
+    ($adapter:expr, $msg:expr) => {
+        debug!("yubihsm-connector({}) {}", $adapter.host, $msg);
+    };
+    ($adapter:expr, $fmt:expr, $($arg:tt)+) => {
+        debug!(concat!("yubihsm-connector({}) ", $fmt), $adapter.host, $($arg)+);
+    };
+}

--- a/src/adapters/http/mod.rs
+++ b/src/adapters/http/mod.rs
@@ -9,15 +9,8 @@
 //! in environments (e.g. Intel SGX) where it might be difficult to use a
 //! full-fledged HTTP crate (e.g. hyper).
 
-/// Write consistent `debug!(...) lines for adapters
-macro_rules! http_debug {
-    ($adapter:expr, $msg:expr) => {
-        debug!("yubihsm-connector({}) {}", $adapter.host, $msg);
-    };
-    ($adapter:expr, $fmt:expr, $($arg:tt)+) => {
-        debug!(concat!("yubihsm-connector({}) ", $fmt), $adapter.host, $($arg)+);
-    };
-}
+#[macro_use]
+mod macros;
 
 mod adapter;
 mod config;

--- a/src/adapters/usb/hsm_device.rs
+++ b/src/adapters/usb/hsm_device.rs
@@ -1,0 +1,83 @@
+use libusb;
+use std::{
+    fmt::{self, Debug},
+    time::Duration,
+};
+
+use super::{UsbAdapter, UsbTimeout, YUBIHSM2_BULK_IN_ENDPOINT, YUBIHSM2_INTERFACE_NUM};
+use adapters::AdapterError;
+use securechannel::MAX_MSG_SIZE;
+use serial_number::SerialNumber;
+
+/// A USB device we've identified as a YubiHSM2
+pub struct HsmDevice {
+    /// Serial number of the YubiHSM2 device
+    pub serial_number: SerialNumber,
+
+    /// Underlying `libusb` device
+    pub(super) device: libusb::Device<'static>,
+}
+
+impl HsmDevice {
+    /// Create a new device
+    pub(super) fn new(device: libusb::Device<'static>, serial_number: SerialNumber) -> Self {
+        Self {
+            serial_number,
+            device,
+        }
+    }
+
+    /// Open this device, consuming it and creating a `UsbAdapter`
+    pub fn open(self, timeout: UsbTimeout) -> Result<UsbAdapter, AdapterError> {
+        UsbAdapter::new(self, timeout)
+    }
+
+    /// Get the bus number for this device
+    pub fn bus_number(&self) -> u8 {
+        self.device.bus_number()
+    }
+
+    /// Get the address for this device
+    pub fn address(&self) -> u8 {
+        self.device.address()
+    }
+
+    /// Open a handle to the underlying device (for use by `UsbAdapter`)
+    pub(super) fn open_handle(&self) -> Result<libusb::DeviceHandle<'static>, AdapterError> {
+        let mut handle = self.device.open()?;
+        handle.reset()?;
+        handle.claim_interface(YUBIHSM2_INTERFACE_NUM)?;
+
+        // Flush any unconsumed messages still in the buffer
+        flush(&mut handle)?;
+
+        Ok(handle)
+    }
+}
+
+impl Debug for HsmDevice {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "HsmDevice(bus={} addr={} serial=#{})",
+            self.bus_number(),
+            self.address(),
+            self.serial_number,
+        )
+    }
+}
+
+/// Flush any unconsumed messages still in the buffer to get the connection
+/// back into a clean state
+fn flush(handle: &mut libusb::DeviceHandle) -> Result<(), AdapterError> {
+    let mut buffer = [0u8; MAX_MSG_SIZE];
+
+    // Use a near instantaneous (but non-zero) timeout to drain the buffer.
+    // Zero is interpreted as wait forever.
+    let timeout = Duration::from_millis(1);
+
+    match handle.read_bulk(YUBIHSM2_BULK_IN_ENDPOINT, &mut buffer, timeout) {
+        Ok(_) | Err(libusb::Error::Timeout) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/src/adapters/usb/macros.rs
+++ b/src/adapters/usb/macros.rs
@@ -1,0 +1,40 @@
+/// Write consistent `debug!(...) lines for `UsbAdapter`
+macro_rules! usb_debug {
+    ($device:expr, $msg:expr) => {
+        debug!(
+            concat!("USB(bus={},addr={}): ", $msg),
+            $device.bus_number(),
+            $device.address(),
+        );
+    };
+    ($device:expr, $fmt:expr, $($arg:tt)+) => {
+        debug!(
+            concat!("USB(bus={},addr={}): ", $fmt),
+            $device.bus_number(),
+            $device.address(),
+            $($arg)+
+        );
+    };
+}
+
+/// Create `UsbError`s that include bus and address information
+macro_rules! usb_err {
+    ($device:expr, $msg:expr) => {
+        err!(
+            UsbError,
+            "USB(bus={},addr={}): {}",
+            $device.bus_number(),
+            $device.address(),
+            $msg
+        );
+    };
+    ($device:expr, $fmt:expr, $($arg:tt)+) => {
+        err!(
+            UsbError,
+            concat!("USB(bus={},addr={}): ", $fmt),
+            $device.bus_number(),
+            $device.address(),
+            $($arg)+
+        );
+    };
+}

--- a/src/adapters/usb/mod.rs
+++ b/src/adapters/usb/mod.rs
@@ -1,11 +1,31 @@
 //! Support for interacting directly with the YubiHSM 2 via USB
 
+#[macro_use]
+mod macros;
+
 mod adapter;
 mod config;
 mod devices;
+mod hsm_device;
 mod timeout;
 
 pub use self::adapter::UsbAdapter;
 pub use self::config::UsbConfig;
-pub use self::devices::{HsmDevice, UsbDevices};
+pub use self::devices::UsbDevices;
+pub use self::hsm_device::HsmDevice;
 pub use self::timeout::UsbTimeout;
+
+/// USB vendor ID for Yubico
+pub const YUBICO_VENDOR_ID: u16 = 0x1050;
+
+/// USB product ID for the YubiHSM2
+pub const YUBIHSM2_PRODUCT_ID: u16 = 0x0030;
+
+/// YubiHSM 2 USB interface number
+pub const YUBIHSM2_INTERFACE_NUM: u8 = 0;
+
+/// YubiHSM 2 bulk out endpoint
+pub const YUBIHSM2_BULK_OUT_ENDPOINT: u8 = 1;
+
+/// YubiHSM 2 bulk in endpoint
+pub const YUBIHSM2_BULK_IN_ENDPOINT: u8 = 0x81;


### PR DESCRIPTION
Makes `adapters::usb::HsmDevice` wrap `libusb::Device` and stores it with the `UsbAdapter`, and exposes additional info like bus and device addresses.