### PR TITLE
v0.17.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [0.17.1] (2018-09-19)
+
+[0.17.1]: https://github.com/tendermint/yubihsm-rs/pull/125
+
+* [#124](https://github.com/tendermint/yubihsm-rs/pull/124)
+  UsbDevices: add `len()`, `is_empty()`, `as_slice()`, and `into_iter()`.
+
+* [#123](https://github.com/tendermint/yubihsm-rs/pull/123)
+  adapter/usb: Don't verbosely log every discovered YubiHSM2.
+
 ## [0.17.0] (2018-09-19)
 
 [0.17.0]: https://github.com/tendermint/yubihsm-rs/pull/122

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "yubihsm"
 description   = "Pure Rust client for YubiHSM2 devices"
-version       = "0.17.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.17.1" # Also update html_root_url in lib.rs when bumping this
 license       = "MIT OR Apache-2.0"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/master/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.17.0"
+    html_root_url = "https://docs.rs/yubihsm/0.17.1"
 )]
 
 extern crate aes;


### PR DESCRIPTION
[Diff from 0.17.0](https://github.com/tendermint/yubihsm-rs/compare/v0.17.0...v0.17.1)

- #124: `UsbDevices`: add `len()`, `is_empty()`, `as_slice()`, and `into_iter()`.
- #123: adapter/usb: Don't verbosely log every discovered YubiHSM2.