### PR TITLE
v0.18.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## [0.18.0] (2018-10-03)
+
+[0.18.0]: https://github.com/tendermint/yubihsm-rs/pull/139
+
+* [#138](https://github.com/tendermint/yubihsm-rs/pull/138)
+  Use the zeroize crate.
+
+* [#136](https://github.com/tendermint/yubihsm-rs/pull/136)
+  `Session`: add `messages_sent()`.
+
+* [#131](https://github.com/tendermint/yubihsm-rs/pull/131)
+  API overhaul: eliminate adapter-related generics with trait objects.
+
 ## [0.17.3] (2018-09-21)
 
 [0.17.3]: https://github.com/tendermint/yubihsm-rs/pull/130

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name          = "yubihsm"
 description   = "Pure Rust client for YubiHSM2 devices"
-version       = "0.18.0-alpha1" # Also update html_root_url in lib.rs when bumping this
-license       = "MIT OR Apache-2.0"
+version       = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"
 homepage      = "https://github.com/tendermint/yubihsm-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/master/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.18.0-alpha1"
+    html_root_url = "https://docs.rs/yubihsm/0.18.0"
 )]
 
 extern crate aes;


### PR DESCRIPTION
[Diff from 0.17.3](https://github.com/tendermint/yubihsm-rs/compare/v0.17.3...v0.18.0)

- #138: Use the zeroize crate.
- #136: `Session`: add `messages_sent()`.
- #131: API overhaul: eliminate adapter-related generics with trait objects.