### PR TITLE
Cargo.toml: Don't build the nightly feature on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rsa = ["sha2"]
 usb = ["lazy_static", "libusb"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["mockhsm", "rsa", "usb"]
 rustc-args = ["-Ctarget-feature=+aes"]
 
 [[bench]]


### PR DESCRIPTION
It uses 1.28: https://docs.rs/crate/yubihsm/0.18.0/builds/119387