### PR TITLE
v0.18.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.18.1] (2018-10-03)
+
+[0.18.1]: https://github.com/tendermint/yubihsm-rs/pull/141
+
+* [#140](https://github.com/tendermint/yubihsm-rs/pull/140)
+  `Cargo.toml`: Don't build the nightly feature on docs.rs.
+
 ## [0.18.0] (2018-10-03)
 
 [0.18.0]: https://github.com/tendermint/yubihsm-rs/pull/139

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "yubihsm"
 description   = "Pure Rust client for YubiHSM2 devices"
-version       = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.18.1" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/master/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.18.0"
+    html_root_url = "https://docs.rs/yubihsm/0.18.1"
 )]
 
 extern crate aes;


### PR DESCRIPTION
[Diff from 0.18.0](https://github.com/tendermint/yubihsm-rs/compare/v0.18.0...v0.18.1)

- #140: `Cargo.toml`: Don't build the nightly feature on docs.rs.