### PR TITLE
Upgrade digest 0.8 (and all transitive dependencies)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,23 +15,23 @@ keywords      = ["ed25519", "hmac", "hsm", "signing", "yubikey"]
 circle-ci = { repository = "tendermint/yubihsm-rs" }
 
 [dependencies]
-aes = "0.2"
+aes = "0.3"
 bitflags = "1"
-block-modes = "0.1"
+block-modes = "0.2"
 byteorder = "1.2"
-cmac = "0.1"
+cmac = "0.2"
 failure = "0.1"
 failure_derive = "0.1"
-hmac = { version = "0.6", optional = true }
+hmac = { version = "0.7", optional = true }
 lazy_static = { version = "1", optional = true }
 libusb = { version = "0.3", optional = true }
 log = "0.4"
-pbkdf2 = { version = "0.2", optional = true }
+pbkdf2 = { version = "0.3", optional = true }
 rand = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 ring = { version = "0.13", optional = true }
-sha2 = { version = "0.7", optional = true }
+sha2 = { version = "0.8", optional = true }
 subtle = "1"
 untrusted = { version = "0.6", optional = true }
 uuid = { version = "0.7", default-features = false, features = ["v4"] }


### PR DESCRIPTION
This upgrades the digest crate and all crates which (transitively) depend on it.