### PR TITLE
session: Clear SecureChannel on encryption failure

### DIFF
--- a/src/session/securechannel/mod.rs
+++ b/src/session/securechannel/mod.rs
@@ -151,7 +151,7 @@ impl SecureChannel {
             self.terminate();
             fail!(
                 CommandLimitExceeded,
-                "max of {} command per session exceeded",
+                "session limit of {} messages exceeded",
                 MAX_COMMANDS_PER_SESSION
             );
         }


### PR DESCRIPTION
Sessions MUST be terminated on any cryptographic failure