### PR TITLE
Use subtle v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = "1.0"
 serde_derive = "1.0"
 ring = { version = "0.13", optional = true }
 sha2 = { version = "0.8", optional = true }
-subtle = "1"
+subtle = "2"
 untrusted = { version = "0.6", optional = true }
 uuid = { version = "0.7", default-features = false, features = ["v4"] }
 zeroize = "0.4"


### PR DESCRIPTION
I'm not sure whether this is a semver breaking change, because I'm not sure whether the `Mac` and `Cryptogram` types (which implement `ConstantTimeEq`) are exported.  If they're not, this can be changed in a minor version, otherwise, it's a semver breaking change.

A bunch of the tests fail on my machine but I think they may be tests that try to talk to the HSM (which I don't have).