### PR TITLE
docs: Bump min Rust version to 1.31+ and add  '+ssse3' to RUSTFLAGS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ usb = ["lazy_static", "libusb"]
 
 [package.metadata.docs.rs]
 features = ["mockhsm", "rsa", "usb"]
-rustc-args = ["-Ctarget-feature=+aes"]
 
 [[bench]]
 name = "ed25519"

--- a/README.md
+++ b/README.md
@@ -39,18 +39,20 @@ or endorsed by Yubico (although whoever runs their Twitter account
 
 ## Prerequisites
 
-This crate builds on Rust 1.27+ and by default uses SIMD features
-which require the following RUSTFLAGS:
+This crate builds on Rust 1.31+.
+
+On x86(-64) targets, add the following `RUSTFLAGS` to enable AES-NI to better
+secure communication with the YubiHSM:
 
 ```
-RUSTFLAGS=-Ctarget-feature=+aes`
+RUSTFLAGS=-Ctarget-feature=+aes,+ssse3`
 ```
 
 You can configure your `~/.cargo/config` to always pass these flags:
 
 ```toml
 [build]
-rustflags = ["-Ctarget-feature=+aes"]
+rustflags = ["-Ctarget-feature=+aes,+ssse3"]
 ```
 
 ## Supported Commands

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,16 @@
 //!
 //! ## Prerequisites
 //!
-//! This crate builds on Rust 1.27+ and by default uses SIMD features
+//! This crate builds on Rust 1.31+ and by default uses SIMD features
 //! which require the following `RUSTFLAGS`:
 //!
-//! `RUSTFLAGS=-Ctarget-feature=+aes`
+//! `RUSTFLAGS=-Ctarget-feature=+aes,+ssse3`
 //!
 //! You can configure your `~/.cargo/config` to always pass these flags:
 //!
 //! ```toml
 //! [build]
-//! rustflags = ["-Ctarget-feature=+aes"]
+//! rustflags = ["-Ctarget-feature=+aes,+ssse3"]
 //! ```
 //!
 //! # Getting Started


### PR DESCRIPTION
This is a 2018 edition crate now, so we need Rust 1.31 at a minimum.

The `aesni` crate depends on `+ssse3` to enable AES-NI, so document that requirement.