### PR TITLE
v0.20.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.20.0] (2019-02-12)
+
+- Match Yubico's API changes from their latest SDK release ([#167])
+- Upgrade `ring` crate to `v0.14`; switch to `rand_os` crate `v0.1` ([#166])
+- Update to Rust 2018 edition ([#164])
+- Upgrade `subtle` crate to `v2` ([#163])
+
 ## [0.19.2] (2018-11-27)
 
 - `HttpConnector`: upgrade to `gaunt` v0.1.0 (#157)
@@ -197,6 +204,12 @@ to adding support for several commands.
 
 - Initial release
 
+[0.20.0]: https://github.com/tendermint/yubihsm-rs/pull/172
+[#167]: https://github.com/tendermint/yubihsm-rs/pull/167
+[#166]: https://github.com/tendermint/yubihsm-rs/pull/166
+[#164]: https://github.com/tendermint/yubihsm-rs/pull/164
+[#163]: https://github.com/tendermint/yubihsm-rs/pull/163
+[0.19.2]: https://github.com/tendermint/yubihsm-rs/pull/159
 [0.19.1]: https://github.com/tendermint/yubihsm-rs/pull/153
 [0.19.0]: https://github.com/tendermint/yubihsm-rs/pull/150
 [0.18.1]: https://github.com/tendermint/yubihsm-rs/pull/141

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 USB-based access to the device. Supports most HSM functionality
                 including ECDSA, Ed25519, HMAC, and RSA.
                 """
-version       = "0.20.0-alpha1" # Also update html_root_url in lib.rs when bumping this
+version       = "0.20.0" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/master/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.20.0-alpha1"
+    html_root_url = "https://docs.rs/yubihsm/0.20.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Match Yubico's API changes from their latest SDK release (#167)
- Upgrade `ring` crate to `v0.14`; switch to `rand_os` crate `v0.1` (#166)
- Update to Rust 2018 edition (#164)
- Upgrade `subtle` crate to `v2` (#163)