### PR TITLE
Integrate signatory-yubihsm into this crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,9 @@ serde = "1"
 serde_derive = "1"
 serde_json = { version = "1", optional = true }
 ring = { version = "0.14", optional = true }
+secp256k1 = { version = "0.12", optional = true }
 sha2 = { version = "0.8", optional = true }
+signatory = { version = "0.11", features = ["digest", "ecdsa", "ed25519"], optional = true }
 subtle = "2"
 untrusted = { version = "0.6", optional = true }
 uuid = { version = "0.7", default-features = false, features = ["v4"] }
@@ -49,10 +51,12 @@ zeroize = "0.4"
 criterion = "0.2"
 lazy_static = "1"
 ring = "0.14"
+signatory-ring = "0.11"
+signatory-secp256k1 = "0.11"
 untrusted = "0.6"
 
 [features]
-default = ["http", "passwords", "setup"]
+default = ["http", "passwords", "setup", "signatory"]
 http = ["gaunt"]
 mockhsm = ["passwords", "ring", "untrusted"]
 nightly = ["subtle/nightly", "zeroize/nightly"]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -803,12 +803,8 @@ impl Client {
     /// the signatures. One option for this is the `secp256k1` crate's
     /// [Signature::normalize_s] function.
     ///
-    /// The [signatory-yubihsm] crate automatically normalizes secp256k1 ECDSA
-    /// signatures to "low S" form. Consider using that if you'd like a ready-made
-    /// solution for cryptocurrency applications.
-    ///
-    /// [Signature::normalize_s]: https://docs.rs/secp256k1/latest/secp256k1/struct.Signature.html#method.normalize_s
-    /// [signatory-yubihsm]: https://docs.rs/signatory-yubihsm/latest/signatory_yubihsm/ecdsa/struct.ECDSASigner.html
+    /// Normalization functionality is built into the `yubihsm::signatory` API
+    /// found in this crate (when the `secp256k1` feature is enabled).
     pub fn sign_ecdsa<T>(
         &mut self,
         key_id: object::Id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,10 @@ pub mod session;
 #[cfg(feature = "setup")]
 pub mod setup;
 
+/// Implementations of the Signatory abstract signature API
+#[cfg(feature = "signatory")]
+pub mod signatory;
+
 /// Objects stored in the HSM.
 ///
 /// For more information, see:

--- a/src/signatory/ecdsa.rs
+++ b/src/signatory/ecdsa.rs
@@ -1,0 +1,222 @@
+//! ECDSA provider for the YubiHSM2 crate (supporting NIST P-256 and secp256k1).
+//!
+//! To enable secp256k1 support, you need to build `signatory-yubihsm` with the
+//! `secp256k1` cargo feature enabled.
+
+use super::Session;
+use crate::{object, AsymmetricAlg, Client};
+#[cfg(feature = "secp256k1")]
+use signatory::ecdsa::curve::Secp256k1;
+use signatory::{
+    ecdsa::{
+        curve::{NistP256, NistP384, WeierstrassCurve, WeierstrassCurveKind},
+        Asn1Signature, FixedSignature, PublicKey,
+    },
+    error::Error,
+    generic_array::{
+        typenum::{U32, U48},
+        GenericArray,
+    },
+    Digest, DigestSigner, PublicKeyed, Signature,
+};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, Mutex},
+};
+
+/// ECDSA signature provider for yubihsm-client
+pub struct EcdsaSigner<C>
+where
+    C: WeierstrassCurve,
+{
+    /// YubiHSM client
+    hsm: Arc<Mutex<Client>>,
+
+    /// ID of an ECDSA key to perform signatures with
+    signing_key_id: object::Id,
+
+    /// Placeholder for elliptic curve type
+    curve: PhantomData<C>,
+}
+
+impl<C> EcdsaSigner<C>
+where
+    C: WeierstrassCurve,
+{
+    /// Create a new YubiHSM-backed ECDSA signer
+    pub(crate) fn create(session: &Session, signing_key_id: object::Id) -> Result<Self, Error> {
+        let signer = Self {
+            hsm: session.0.clone(),
+            signing_key_id,
+            curve: PhantomData,
+        };
+
+        // Ensure the signing_key_id slot contains a valid ECDSA public key
+        signer.public_key()?;
+
+        Ok(signer)
+    }
+
+    /// Get the expected `AsymmetricAlg` for this `Curve`
+    pub fn asymmetric_alg() -> AsymmetricAlg {
+        match C::CURVE_KIND {
+            WeierstrassCurveKind::NistP256 => AsymmetricAlg::EC_P256,
+            WeierstrassCurveKind::NistP384 => AsymmetricAlg::EC_P384,
+            WeierstrassCurveKind::Secp256k1 => AsymmetricAlg::EC_K256,
+        }
+    }
+}
+
+impl<C> PublicKeyed<PublicKey<C>> for EcdsaSigner<C>
+where
+    C: WeierstrassCurve,
+{
+    /// Obtain the public key which identifies this signer
+    fn public_key(&self) -> Result<PublicKey<C>, Error> {
+        let mut hsm = self.hsm.lock().unwrap();
+
+        let pubkey = hsm
+            .get_public_key(self.signing_key_id)
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        if pubkey.algorithm != Self::asymmetric_alg() {
+            fail!(
+                KeyInvalid,
+                "expected a {} key, got: {:?}",
+                C::CURVE_KIND.to_str(),
+                pubkey.algorithm
+            );
+        }
+
+        Ok(PublicKey::from_untagged_point(GenericArray::from_slice(
+            pubkey.as_ref(),
+        )))
+    }
+}
+
+impl<D> DigestSigner<D, Asn1Signature<NistP256>> for EcdsaSigner<NistP256>
+where
+    D: Digest<OutputSize = U32> + Default,
+{
+    /// Compute an ASN.1 DER-encoded P-256 ECDSA signature of the given digest
+    fn sign(&self, digest: D) -> Result<Asn1Signature<NistP256>, Error> {
+        self.sign_nistp256_asn1(digest)
+    }
+}
+
+impl<D> DigestSigner<D, FixedSignature<NistP256>> for EcdsaSigner<NistP256>
+where
+    D: Digest<OutputSize = U32> + Default,
+{
+    /// Compute a fixed-sized P-256 ECDSA signature of the given digest
+    fn sign(&self, digest: D) -> Result<FixedSignature<NistP256>, Error> {
+        Ok(FixedSignature::from(&self.sign_nistp256_asn1(digest)?))
+    }
+}
+
+impl<D> DigestSigner<D, Asn1Signature<NistP384>> for EcdsaSigner<NistP384>
+where
+    D: Digest<OutputSize = U48> + Default,
+{
+    /// Compute an ASN.1 DER-encoded P-384 ECDSA signature of the given digest
+    fn sign(&self, digest: D) -> Result<Asn1Signature<NistP384>, Error> {
+        self.sign_nistp384_asn1(digest)
+    }
+}
+
+impl<D> DigestSigner<D, FixedSignature<NistP384>> for EcdsaSigner<NistP384>
+where
+    D: Digest<OutputSize = U48> + Default,
+{
+    /// Compute a fixed-sized P-384 ECDSA signature of the given digest
+    fn sign(&self, digest: D) -> Result<FixedSignature<NistP384>, Error> {
+        Ok(FixedSignature::from(&self.sign_nistp384_asn1(digest)?))
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+impl<D> DigestSigner<D, Asn1Signature<Secp256k1>> for EcdsaSigner<Secp256k1>
+where
+    D: Digest<OutputSize = U32> + Default,
+{
+    /// Compute an ASN.1 DER-encoded secp256k1 ECDSA signature of the given digest
+    fn sign(&self, digest: D) -> Result<Asn1Signature<Secp256k1>, Error> {
+        let asn1_sig = self.sign_secp256k1(digest)?.serialize_der();
+
+        Ok(Asn1Signature::from_bytes(&asn1_sig).unwrap())
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+impl<D> DigestSigner<D, FixedSignature<Secp256k1>> for EcdsaSigner<Secp256k1>
+where
+    D: Digest<OutputSize = U32> + Default,
+{
+    /// Compute a fixed-size secp256k1 ECDSA signature of the given digest
+    fn sign(&self, digest: D) -> Result<FixedSignature<Secp256k1>, Error> {
+        let fixed_sig =
+            GenericArray::clone_from_slice(&self.sign_secp256k1(digest)?.serialize_compact());
+
+        Ok(FixedSignature::from(fixed_sig))
+    }
+}
+
+impl EcdsaSigner<NistP256> {
+    /// Compute an ASN.1 DER signature over P-256
+    fn sign_nistp256_asn1<D>(&self, digest: D) -> Result<Asn1Signature<NistP256>, Error>
+    where
+        D: Digest<OutputSize = U32> + Default,
+    {
+        let mut hsm = self.hsm.lock().unwrap();
+
+        let signature = hsm
+            .sign_ecdsa(self.signing_key_id, digest.result().as_slice())
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        Asn1Signature::from_bytes(signature)
+    }
+}
+
+impl EcdsaSigner<NistP384> {
+    /// Compute an ASN.1 DER signature over P-384
+    fn sign_nistp384_asn1<D>(&self, digest: D) -> Result<Asn1Signature<NistP384>, Error>
+    where
+        D: Digest<OutputSize = U48> + Default,
+    {
+        let mut hsm = self.hsm.lock().unwrap();
+
+        let signature = hsm
+            .sign_ecdsa(self.signing_key_id, digest.result().as_slice())
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        Asn1Signature::from_bytes(signature)
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+impl EcdsaSigner<Secp256k1> {
+    /// Compute either an ASN.1 DER or fixed-sized signature using libsecp256k1
+    fn sign_secp256k1<D>(&self, digest: D) -> Result<secp256k1::Signature, Error>
+    where
+        D: Digest<OutputSize = U32> + Default,
+    {
+        let mut hsm = self.hsm.lock().unwrap();
+
+        // Sign the data using the YubiHSM, producing an ASN.1 DER encoded signature
+        let raw_sig = hsm
+            .sign_ecdsa(self.signing_key_id, digest.result().as_slice())
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        // Parse the signature using libsecp256k1
+        let mut sig = secp256k1::Signature::from_der_lax(raw_sig.as_ref()).unwrap();
+
+        // Normalize the signature to a "low S" form. libsecp256k1 will only
+        // accept signatures for which s is in the lower half of the field range.
+        // The signatures produced by the YubiHSM do not have this property, so
+        // we normalize them to maximize compatibility with secp256k1
+        // applications (e.g. Bitcoin).
+        sig.normalize_s();
+
+        Ok(sig)
+    }
+}

--- a/src/signatory/ed25519.rs
+++ b/src/signatory/ed25519.rs
@@ -1,0 +1,65 @@
+//! Digital signature (i.e. Ed25519) provider for `YubiHSM2` devices
+//!
+//! To use this provider, first establish a session with the `YubiHSM2`, then
+//! call the appropriate signer methods to obtain signers.
+
+use super::Session;
+use crate::{object, AsymmetricAlg, Client};
+use signatory::{
+    ed25519,
+    error::{Error, ErrorKind},
+    PublicKeyed, Signature, Signer,
+};
+use std::sync::{Arc, Mutex};
+
+/// Ed25519 signature provider for yubihsm-client
+pub struct Ed25519Signer {
+    /// Session with the YubiHSM
+    hsm: Arc<Mutex<Client>>,
+
+    /// ID of an Ed25519 key to perform signatures with
+    signing_key_id: object::Id,
+}
+
+impl Ed25519Signer {
+    /// Create a new YubiHSM-backed Ed25519 signer
+    pub(crate) fn create(session: &Session, signing_key_id: object::Id) -> Result<Self, Error> {
+        let signer = Self {
+            hsm: session.0.clone(),
+            signing_key_id,
+        };
+
+        // Ensure the signing_key_id slot contains a valid Ed25519 public key
+        signer.public_key()?;
+
+        Ok(signer)
+    }
+}
+
+impl PublicKeyed<ed25519::PublicKey> for Ed25519Signer {
+    fn public_key(&self) -> Result<ed25519::PublicKey, Error> {
+        let mut hsm = self.hsm.lock().unwrap();
+
+        let pubkey = hsm
+            .get_public_key(self.signing_key_id)
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        if pubkey.algorithm != AsymmetricAlg::Ed25519 {
+            return Err(ErrorKind::KeyInvalid.into());
+        }
+
+        Ok(ed25519::PublicKey::from_bytes(pubkey.as_ref()).unwrap())
+    }
+}
+
+impl Signer<ed25519::Signature> for Ed25519Signer {
+    fn sign(&self, msg: &[u8]) -> Result<ed25519::Signature, Error> {
+        let mut hsm = self.hsm.lock().unwrap();
+
+        let signature = hsm
+            .sign_ed25519(self.signing_key_id, msg)
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        Ok(ed25519::Signature::from_bytes(signature.as_ref()).unwrap())
+    }
+}

--- a/src/signatory/error.rs
+++ b/src/signatory/error.rs
@@ -1,0 +1,24 @@
+#![allow(unused_macros)]
+
+/// Create a new error (of a given enum variant) with a formatted message
+macro_rules! err {
+    ($variant:ident, $msg:expr) => {
+        ::signatory::error::Error::new(
+            ::signatory::error::ErrorKind::$variant,
+            Some($msg)
+        )
+    };
+    ($variant:ident, $fmt:expr, $($arg:tt)+) => {
+        err!($variant, &format!($fmt, $($arg)+))
+    };
+}
+
+/// Create and return an error with a formatted message
+macro_rules! fail {
+    ($kind:ident, $msg:expr) => {
+        return Err(err!($kind, $msg).into());
+    };
+    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
+        return Err(err!($kind, $fmt, $($arg)+).into());
+    };
+}

--- a/src/signatory/mod.rs
+++ b/src/signatory/mod.rs
@@ -1,0 +1,12 @@
+/// Signatory adapter: multi-provider digital signature library for Rust
+///
+/// <https://github.com/tendermint/signatory>
+
+#[macro_use]
+mod error;
+pub mod ecdsa;
+pub mod ed25519;
+mod session;
+
+pub use self::{ecdsa::EcdsaSigner, ed25519::Ed25519Signer, session::Session};
+pub use signatory::Signer;

--- a/src/signatory/session.rs
+++ b/src/signatory/session.rs
@@ -1,0 +1,108 @@
+use super::{ecdsa::EcdsaSigner, ed25519::Ed25519Signer};
+use crate::{object, session, Client, Connector, Credentials};
+use signatory::{ecdsa::curve::WeierstrassCurve, Error};
+use std::sync::{Arc, Mutex};
+
+/// End-to-end encrypted session with the `YubiHSM`
+pub struct Session(pub(super) Arc<Mutex<Client>>);
+
+impl Session {
+    /// Connect to the YubiHSM and open a new session
+    pub fn create<C>(connector: C, credentials: Credentials) -> Result<Self, Error>
+    where
+        C: Into<Box<Connector>>,
+    {
+        let mut session = Self::new(connector, credentials)?;
+        session.open()?;
+        Ok(session)
+    }
+
+    /// Initialize a new encrypted session, deferring actually establishing
+    /// a session until `connect()` is called
+    pub fn new<C>(connector: C, credentials: Credentials) -> Result<Self, Error>
+    where
+        C: Into<Box<Connector>>,
+    {
+        Client::create(connector, credentials)
+            .map(|c| Session(Arc::new(Mutex::new(c))))
+            .map_err(|e| err!(ProviderError, "{}", e))
+    }
+
+    /// Connect to the YubiHSM
+    pub fn open(&mut self) -> Result<(), Error> {
+        let mut hsm = self.0.lock().unwrap();
+
+        if let Err(e) = hsm.connect() {
+            fail!(ProviderError, "{}", e);
+        }
+
+        Ok(())
+    }
+
+    /// Do we currently have an open session with the HSM?
+    pub fn is_open(&self) -> bool {
+        let hsm = self.0.lock().unwrap();
+        hsm.is_connected()
+    }
+
+    /// Get the current session ID
+    #[inline]
+    pub fn id(&self) -> Option<session::Id> {
+        let mut hsm = self.0.lock().unwrap();
+        hsm.session().map(|s| s.id()).ok()
+    }
+
+    /// Get the underlying `Client` object
+    pub fn client(&self) -> Arc<Mutex<Client>> {
+        self.0.clone()
+    }
+
+    /// Create an ECDSA signer which uses this session. You will need to supply
+    /// an elliptic curve to use when creating a signer:
+    ///
+    /// ```rust,ignore
+    /// extern crate signatory;
+    /// extern crate signatory_yubihsm;
+    ///
+    /// use signatory::{curve::NISTP256, ecdsa::signer::SHA256Signer};
+    /// use signatory_Session;
+    ///
+    /// // Create a YubiHSM2 session using the default configuration
+    /// // WARNING: Don't use this in production!!!
+    /// let session = Session::create_from_password(
+    ///     Default::default(),
+    ///     1,
+    ///     "password"
+    /// ).unwrap();
+    ///
+    /// // Note: You'll need to create a NIST P-256 key in slot `123` first.
+    /// // Run the following from yubihsm-shell:
+    /// // `generate asymmetric 0 123 p256_test_key 1 asymmetric_sign_ecdsa ecp256`
+    /// let key_id = 123;
+    ///
+    /// // This will return an error unless there is already a NIST P-256 key
+    /// // in slot 123
+    /// let signer = session.ecdsa_signer::<NISTP256>(key_id).unwrap();
+    ///
+    /// let message = b"Hello, world!";
+    /// let signature = signer.sign_sha256_der(message).unwrap();
+    /// ```
+    ///
+    /// Supported elliptic curves are:
+    ///
+    /// * `signatory::curve::NISTP256`: NIST P-256 elliptic curve,
+    ///   a.k.a. prime256v1 or secp256r1
+    /// * `signatory::curve::Secp256k1`: secp256k1 elliptic curve
+    ///   (used by Bitcoin)
+    pub fn ecdsa_signer<C>(&self, signing_key_id: object::Id) -> Result<EcdsaSigner<C>, Error>
+    where
+        C: WeierstrassCurve,
+    {
+        EcdsaSigner::create(self, signing_key_id)
+    }
+
+    /// Create an Ed25519 signer which uses this session
+    pub fn ed25519_signer(&self, signing_key_id: object::Id) -> Result<Ed25519Signer, Error> {
+        Ed25519Signer::create(self, signing_key_id)
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,6 +19,10 @@ pub mod command;
 /// Cryptographic test vectors taken from standards documents
 mod test_vectors;
 
+/// Signatory tests
+#[cfg(feature = "signatory")]
+mod signatory;
+
 /// Key ID to use for testing keygen/signing
 const TEST_KEY_ID: object::Id = 100;
 

--- a/tests/signatory/ecdsa.rs
+++ b/tests/signatory/ecdsa.rs
@@ -1,0 +1,96 @@
+// TODO: cleanup tests
+#![allow(dead_code, unused_imports)]
+
+use super::support;
+#[cfg(all(feature = "secp256k1", not(feature = "mockhsm")))]
+use signatory::curve::Secp256k1;
+use signatory::{
+    ecdsa::{
+        curve::{NistP256, NistP384, WeierstrassCurve},
+        Asn1Signature,
+    },
+    PublicKeyed,
+};
+use signatory_ring::ecdsa;
+#[cfg(all(feature = "secp256k1", not(feature = "mockhsm")))]
+use signatory_secp256k1::EcdsaVerifier as Secp256k1Verifier;
+use yubihsm::{
+    object,
+    signatory::{EcdsaSigner, Session},
+};
+
+/// Domain IDs for test key
+const TEST_SIGNING_KEY_DOMAINS: yubihsm::Domain = yubihsm::Domain::DOM1;
+
+/// Capability for test key
+const TEST_SIGNING_KEY_CAPABILITIES: yubihsm::Capability = yubihsm::Capability::SIGN_ECDSA;
+
+/// Label for test key
+const TEST_SIGNING_KEY_LABEL: &str = "Signatory test key";
+
+/// Example message to sign
+const TEST_MESSAGE: &[u8] =
+    b"The Elliptic Curve Digital Signature Algorithm (ECDSA) is a variant of the \
+      Digital Signature Algorithm (DSA) which uses elliptic curve cryptography.";
+
+/// Create the signer for this test
+fn create_signer<C>(key_id: object::Id) -> EcdsaSigner<C>
+where
+    C: WeierstrassCurve,
+{
+    let mut session = support::get_session();
+    create_yubihsm_key(&mut session, key_id, EcdsaSigner::<C>::asymmetric_alg());
+
+    session.ecdsa_signer(key_id).unwrap()
+}
+
+/// Create the key on the YubiHSM to use for this test
+fn create_yubihsm_key(session: &mut Session, key_id: object::Id, alg: yubihsm::AsymmetricAlg) {
+    let client_guard = session.client();
+    let mut hsm = client_guard.lock().unwrap();
+
+    // Delete the key in TEST_KEY_ID slot it exists
+    // Ignore errors since the object may not exist yet
+    let _ = hsm.delete_object(key_id, yubihsm::object::Type::AsymmetricKey);
+
+    // Create a new key for testing
+    hsm.generate_asymmetric_key(
+        key_id,
+        TEST_SIGNING_KEY_LABEL.into(),
+        TEST_SIGNING_KEY_DOMAINS,
+        TEST_SIGNING_KEY_CAPABILITIES,
+        alg,
+    )
+    .unwrap();
+}
+
+// Use *ring* to verify NIST P-256 ECDSA signatures
+#[test]
+#[cfg(not(feature = "mockhsm"))]
+fn ecdsa_nistp256_sign_test() {
+    let signer = create_signer::<NistP256>(100);
+    let signature: Asn1Signature<_> = signatory::sign_sha256(&signer, TEST_MESSAGE).unwrap();
+    let verifier = ecdsa::P256Verifier::from(&signer.public_key().unwrap());
+    assert!(signatory::verify_sha256(&verifier, TEST_MESSAGE, &signature).is_ok());
+}
+
+// Use *ring* to verify NIST P-384 ECDSA signatures
+#[cfg(not(feature = "mockhsm"))]
+#[test]
+fn ecdsa_nistp384_sign_test() {
+    let signer = create_signer::<NistP384>(101);
+    let signature: Asn1Signature<_> = signatory::sign_sha384(&signer, TEST_MESSAGE).unwrap();
+    let verifier = ecdsa::P384Verifier::from(&signer.public_key().unwrap());
+    assert!(signatory::verify_sha384(&verifier, TEST_MESSAGE, &signature).is_ok());
+}
+
+// Use `secp256k1` crate to verify secp256k1 ECDSA signatures.
+// The MockHSM does not presently support secp256k1
+#[cfg(all(feature = "secp256k1", not(feature = "mockhsm")))]
+#[test]
+fn ecdsa_secp256k1_sign_test() {
+    let signer = create_signer::<Secp256k1>(102);
+    let signature: Asn1Signature<_> = signatory::sign_sha256(&signer, TEST_MESSAGE).unwrap();
+    let verifier = Secp256k1Verifier::from(&signer.public_key().unwrap());
+    assert!(signatory::verify_sha256(&verifier, TEST_MESSAGE, &signature).is_ok());
+}

--- a/tests/signatory/ed25519.rs
+++ b/tests/signatory/ed25519.rs
@@ -1,0 +1,53 @@
+use super::support;
+use signatory::PublicKeyed;
+use signatory_ring::ed25519::Ed25519Verifier;
+use yubihsm::signatory::{Session, Signer};
+
+/// Key ID to use for test key
+const TEST_SIGNING_KEY_ID: yubihsm::object::Id = 200;
+
+/// Domain IDs for test key
+const TEST_SIGNING_KEY_DOMAINS: yubihsm::Domain = yubihsm::Domain::DOM1;
+
+/// Capability for test key
+const TEST_SIGNING_KEY_CAPABILITIES: yubihsm::Capability = yubihsm::Capability::SIGN_EDDSA;
+
+/// Label for test key
+const TEST_SIGNING_KEY_LABEL: &str = "Signatory test key";
+
+/// Example message to sign
+const TEST_MESSAGE: &[u8] =
+    b"The Edwards-curve Digital Signature yubihsm::AsymmetricAlg  (EdDSA) is a \
+        variant of Schnorr's signature system with (possibly twisted) Edwards curves.";
+
+/// Create the key on the YubiHSM to use for this test
+fn create_yubihsm_key(session: &mut Session) {
+    let client_guard = session.client();
+    let mut hsm = client_guard.lock().unwrap();
+
+    // Delete the key in TEST_KEY_ID slot it exists
+    // Ignore errors since the object may not exist yet
+    let _ = hsm.delete_object(TEST_SIGNING_KEY_ID, yubihsm::object::Type::AsymmetricKey);
+
+    // Create a new key for testing
+    hsm.generate_asymmetric_key(
+        TEST_SIGNING_KEY_ID,
+        TEST_SIGNING_KEY_LABEL.into(),
+        TEST_SIGNING_KEY_DOMAINS,
+        TEST_SIGNING_KEY_CAPABILITIES,
+        yubihsm::AsymmetricAlg::Ed25519,
+    )
+    .unwrap();
+}
+
+#[test]
+fn ed25519_sign_test() {
+    let mut session = support::get_session();
+    create_yubihsm_key(&mut session);
+
+    let signer = session.ed25519_signer(TEST_SIGNING_KEY_ID).unwrap();
+    let signature = signer.sign(TEST_MESSAGE).unwrap();
+    let verifier = Ed25519Verifier::from(&signer.public_key().unwrap());
+
+    assert!(signatory::verify(&verifier, TEST_MESSAGE, &signature).is_ok());
+}

--- a/tests/signatory/mod.rs
+++ b/tests/signatory/mod.rs
@@ -1,0 +1,3 @@
+mod ecdsa;
+mod ed25519;
+mod support;

--- a/tests/signatory/support.rs
+++ b/tests/signatory/support.rs
@@ -1,0 +1,68 @@
+use std::sync::{Mutex, MutexGuard};
+use yubihsm::signatory::Session;
+use yubihsm::Connector;
+#[cfg(feature = "http")]
+use yubihsm::HttpConnector;
+#[cfg(feature = "mockhsm")]
+use yubihsm::MockHsm;
+#[cfg(feature = "usb")]
+use yubihsm::UsbConnector;
+
+lazy_static! {
+    static ref HSM_SESSION: Mutex<Session> =
+        { Mutex::new(Session::create(create_hsm_connector(), Default::default()).unwrap()) };
+}
+
+/// Create a `signatory_yubihsm::Session` to run the test suite against
+pub fn get_session() -> MutexGuard<'static, Session> {
+    HSM_SESSION.lock().unwrap()
+}
+
+/// Create a `yubihsm::Connector` for accessing the HSM
+///
+/// Connector is selected by preference based on cargo features.
+/// The preference order is:
+///
+/// 1. `mockhsm`
+/// 2. `usb`
+/// 3. `http`
+///
+/// Panics if none of the above features are enabled
+#[allow(unreachable_code)]
+pub fn create_hsm_connector() -> Box<Connector> {
+    // MockHSM has highest priority when testing
+    #[cfg(feature = "mockhsm")]
+    return create_mockhsm_connector();
+
+    // USB has second highest priority when testing
+    #[cfg(feature = "usb")]
+    return create_usb_connector();
+
+    // HTTP has lowest priority when testing
+    #[cfg(feature = "http")]
+    return create_http_connector();
+
+    panic!(
+        "No connector features enabled! Enable one of these cargo features: \
+         http, usb, mockhsm"
+    );
+}
+
+/// Connect to the HSM via HTTP using `yubihsm-connector`
+#[cfg(feature = "http")]
+pub fn create_http_connector() -> Box<Connector> {
+    HttpConnector::create(&Default::default()).unwrap().into()
+}
+
+/// Connect to the HSM via USB
+#[cfg(feature = "usb")]
+pub fn create_usb_connector() -> Box<Connector> {
+    UsbConnector::create(&Default::default()).unwrap().into()
+}
+
+/// Create a mock HSM for testing in situations where a hardware device is
+/// unavailable/impractical (e.g. CI)
+#[cfg(feature = "mockhsm")]
+pub fn create_mockhsm_connector() -> Box<Connector> {
+    MockHsm::default().into()
+}


### PR DESCRIPTION
This integrates the code which was previously in the `signatory-yubihsm` crate into this crate.

This simplifies making breaking changes to this crate, such that changes to the Signatory adapter can be done atomically as part of the same commit.