### PR TITLE
Provisioning fixups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ mockhsm = ["passwords", "ring", "untrusted"]
 nightly = ["subtle/nightly", "zeroize/nightly"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 rsa = ["sha2"]
-setup = ["chrono", "passwords", "serde_json"]
+setup = ["chrono", "passwords", "serde_json", "uuid/serde"]
 usb = ["lazy_static", "libusb"]
 
 [package.metadata.docs.rs]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -719,7 +719,10 @@ impl Client {
         }
 
         // Resetting the HSM invalidates our session
-        self.session = None;
+        if let Some(ref mut session) = self.session {
+            session.abort();
+        }
+
         Ok(())
     }
 

--- a/src/object/import.rs
+++ b/src/object/import.rs
@@ -28,7 +28,7 @@ impl Params {
         Self {
             id,
             label: object::Label::default(),
-            domains: Domain::all(),
+            domains: Domain::empty(),
             capabilities: Capability::empty(),
             algorithm,
         }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -65,7 +65,7 @@ where
         temp_auth_key.clone(),
     )?;
 
-    debug!(
+    info!(
         "installed temporary setup authentication key into slot {}",
         setup_auth_key_id
     );

--- a/src/setup/profile.rs
+++ b/src/setup/profile.rs
@@ -6,11 +6,13 @@ use crate::{object, wrap, AuditOption, Client};
 use failure::Error;
 use std::time::Duration;
 
-/// Temporary account key to use for device provisioning
-pub const DEFAULT_SETUP_KEY_ID: object::Id = 0xFFFF;
+/// Temporary account key to use for device provisioning.
+/// Uses key ID #65534 as 65535 is reserved for internal use.
+pub const DEFAULT_SETUP_KEY_ID: object::Id = 0xFFFE;
 
 /// Object ID to write reports into after provisioning is complete
-pub const DEFAULT_REPORT_OBJECT_ID: object::Id = 0xFFFF;
+/// Uses key ID #65534 as 65535 is reserved for internal use.
+pub const DEFAULT_REPORT_OBJECT_ID: object::Id = 0xFFFE;
 
 /// YubiHSM2 provisioning profile: a declarative profile specifying how a
 /// device should be (re)provisioned.
@@ -57,6 +59,11 @@ impl Default for Profile {
 }
 
 impl Profile {
+    /// Create a new empty profile
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Configure the auth key ID to use when performing device setup
     pub fn setup_auth_key_id(mut self, key_id: Option<object::Id>) -> Self {
         self.setup_auth_key_id = key_id;

--- a/src/setup/profile.rs
+++ b/src/setup/profile.rs
@@ -99,23 +99,27 @@ impl Profile {
     /// Use this profile to provision the YubiHSM2 with the given client
     pub fn provision(&self, client: &mut Client) -> Result<Report, Error> {
         for role in &self.roles {
-            debug!("installing role: {}", role.authentication_key_label);
+            info!("installing role: {}", role.authentication_key_label);
             role.create(client)?;
         }
 
         for wrap_key in &self.wrap_keys {
-            debug!("installing wrap key: {}", &wrap_key.import_params.label);
+            info!("installing wrap key: {}", &wrap_key.import_params.label);
             wrap_key.create(client)?;
         }
 
         if self.audit_option != AuditOption::Off {
-            debug!("setting force audit to: {:?}", self.audit_option);
+            info!("setting force audit to: {:?}", self.audit_option);
             client.set_force_audit_option(self.audit_option)?;
         }
 
         let report = Report::new();
 
         if let Some(report_object_id) = self.report_object_id {
+            info!(
+                "storing provisioning report in opaque object 0x{:x}",
+                report_object_id
+            );
             report.store(client, report_object_id)?;
         }
 

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::new_without_default)]
 
-use crate::{object, Capability, Client, Domain, OpaqueAlg};
+use crate::{object, Capability, Client, Domain, OpaqueAlg, Uuid};
 use chrono::{DateTime, Utc};
 use failure::Error;
 use std::{env, str::FromStr};
@@ -28,6 +28,9 @@ pub struct Report {
     /// Version of the report
     pub version: Version,
 
+    /// UUID which uniquely identifies this provisioning report
+    pub uuid: Uuid,
+
     /// Hostname the device was provisioned on
     pub hostname: Option<String>,
 
@@ -47,6 +50,7 @@ impl Report {
         // TODO: handle these better on operating systems other than *IX
         Report {
             version: Version::default(),
+            uuid: Uuid::new_v4(),
             username: env::var("LOGNAME").map(|u| u.to_owned()).ok(),
             hostname: env::var("HOSTNAME").map(|h| h.to_owned()).ok(),
             date: Utc::now(),


### PR DESCRIPTION
- Session abort support (used for the Reset Device command)
- Use key IDs 0xFFFE instead of 0xFFFF for the temp setup authentication key, and the provisioning report (xFFFF is reserved for internal use per the Yubico docs)
- Add a UUID to the setup report