### PR TITLE
Add device serial number to provisioning report

### DIFF
--- a/src/setup/profile.rs
+++ b/src/setup/profile.rs
@@ -113,7 +113,7 @@ impl Profile {
             client.set_force_audit_option(self.audit_option)?;
         }
 
-        let report = Report::new();
+        let report = Report::new(client.device_info()?.serial_number);
 
         if let Some(report_object_id) = self.report_object_id {
             info!(

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::new_without_default)]
 
 use crate::{
+    device::SerialNumber,
     object, opaque,
     uuid::{self, Uuid},
     Capability, Client, Domain,
@@ -35,6 +36,9 @@ pub struct Report {
     /// UUID which uniquely identifies this provisioning report
     pub uuid: Uuid,
 
+    /// Serial number of the HSM which was provisioned
+    pub device_serial_number: String,
+
     /// Hostname the device was provisioned on
     pub hostname: Option<String>,
 
@@ -50,11 +54,12 @@ pub struct Report {
 
 impl Report {
     /// Make a new `yubihsm::setup::Report` from the ambient environment state
-    pub fn new() -> Self {
+    pub fn new(serial_number: SerialNumber) -> Self {
         // TODO: handle these better on operating systems other than *IX
         Report {
-            version: Version::default(),
+            version: Version(1),
             uuid: uuid::new_v4(),
+            device_serial_number: serial_number.to_string(),
             username: env::var("LOGNAME").map(|u| u.to_owned()).ok(),
             hostname: env::var("HOSTNAME").map(|h| h.to_owned()).ok(),
             date: Utc::now(),


### PR DESCRIPTION
Helps associate provisioning reports with specific devices.

Also bumps the report version to 1. :shipit: 