### PR TITLE
v0.21.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.21.0] (2019-02-26)
+
+- Factor algorithms into their own Rust modules ([#180])
+- Unify connectors as `struct Connector` ([#179])
+- Integrate signatory-yubihsm ([#176])
+- Refactor and rename `wrap::Message` and `wrap::Nonce` ([#175])
+- Add `setup` module for initial YubiHSM2 provisioning ([#174])
+- Eliminate redundant prefixes in type names ([#173])
+
 ## [0.20.0] (2019-02-12)
 
 - Match Yubico's API changes from their latest SDK release ([#167])
@@ -204,6 +213,13 @@ to adding support for several commands.
 
 - Initial release
 
+[0.21.0]: https://github.com/tendermint/yubihsm-rs/pull/183
+[#180]: https://github.com/tendermint/yubihsm-rs/pull/180
+[#179]: https://github.com/tendermint/yubihsm-rs/pull/179
+[#176]: https://github.com/tendermint/yubihsm-rs/pull/176
+[#175]: https://github.com/tendermint/yubihsm-rs/pull/175
+[#174]: https://github.com/tendermint/yubihsm-rs/pull/174
+[#173]: https://github.com/tendermint/yubihsm-rs/pull/173
 [0.20.0]: https://github.com/tendermint/yubihsm-rs/pull/172
 [#167]: https://github.com/tendermint/yubihsm-rs/pull/167
 [#166]: https://github.com/tendermint/yubihsm-rs/pull/166

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 USB-based access to the device. Supports most HSM functionality
                 including ECDSA, Ed25519, HMAC, and RSA.
                 """
-version       = "0.21.0-alpha2" # Also update html_root_url in lib.rs when bumping this
+version       = "0.21.0" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/master/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.21.0-alpha2"
+    html_root_url = "https://docs.rs/yubihsm/0.21.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Factor algorithms into their own Rust modules (#180)
- Unify connectors as `struct Connector` (#179)
- Integrate signatory-yubihsm (#176)
- Refactor and rename `wrap::Message` and `wrap::Nonce` (#175)
- Add `setup` module for initial YubiHSM2 provisioning (#174)
- Eliminate redundant prefixes in type names (#173)