### PR TITLE
device: Factor info/storage/wrap commands into public types

### DIFF
--- a/src/device/commands/info.rs
+++ b/src/device/commands/info.rs
@@ -1,12 +1,11 @@
-//! Get information about the `YubiHSM 2` device
+//! Get storage information about the `YubiHSM 2` device
 //!
-//! <https://developers.yubico.com/YubiHSM2/Commands/Device_Info.html>
+//! <https://developers.yubico.com/YubiHSM2/Commands/Get_Storage_Info.html>
 
 use crate::{
     command::{self, Command},
-    device::SerialNumber,
+    device,
     response::Response,
-    Algorithm,
 };
 
 /// Request parameters for `command::device_info`
@@ -19,29 +18,14 @@ impl Command for DeviceInfoCommand {
 
 /// Response from `command::device_info`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DeviceInfoResponse {
-    /// Device major version
-    pub major_version: u8,
-
-    /// Device minor version
-    pub minor_version: u8,
-
-    /// Device build version (i.e. patchlevel)
-    pub build_version: u8,
-
-    /// Device serial number
-    pub serial_number: SerialNumber,
-
-    /// Size of the log store (in lines/entries)
-    pub log_store_capacity: u8,
-
-    /// Number of log lines used
-    pub log_store_used: u8,
-
-    /// Supported algorithms
-    pub algorithms: Vec<Algorithm>,
-}
+pub struct DeviceInfoResponse(pub(crate) device::Info);
 
 impl Response for DeviceInfoResponse {
     const COMMAND_CODE: command::Code = command::Code::DeviceInfo;
+}
+
+impl From<DeviceInfoResponse> for device::Info {
+    fn from(response: DeviceInfoResponse) -> device::Info {
+        response.0
+    }
 }

--- a/src/device/commands/storage.rs
+++ b/src/device/commands/storage.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     command::{self, Command},
+    device::storage,
     response::Response,
 };
 
@@ -17,23 +18,14 @@ impl Command for GetStorageInfoCommand {
 
 /// Response from `command::get_storage_info`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct GetStorageInfoResponse {
-    /// Total number of storage records
-    pub total_records: u16,
-
-    /// Storage records which are currently free
-    pub free_records: u16,
-
-    /// Total number of storage pages
-    pub total_pages: u16,
-
-    /// Storage pages which are currently free
-    pub free_pages: u16,
-
-    /// Page size in bytes
-    pub page_size: u16,
-}
+pub struct GetStorageInfoResponse(pub(crate) storage::Info);
 
 impl Response for GetStorageInfoResponse {
     const COMMAND_CODE: command::Code = command::Code::GetStorageInfo;
+}
+
+impl From<GetStorageInfoResponse> for storage::Info {
+    fn from(response: GetStorageInfoResponse) -> storage::Info {
+        response.0
+    }
 }

--- a/src/device/info.rs
+++ b/src/device/info.rs
@@ -1,0 +1,27 @@
+use super::serial;
+use crate::Algorithm;
+
+/// Information about an HSM device
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Info {
+    /// Device major version
+    pub major_version: u8,
+
+    /// Device minor version
+    pub minor_version: u8,
+
+    /// Device build version (i.e. patchlevel)
+    pub build_version: u8,
+
+    /// Device serial number
+    pub serial_number: serial::Number,
+
+    /// Size of the log store (in lines/entries)
+    pub log_store_capacity: u8,
+
+    /// Number of log lines used
+    pub log_store_used: u8,
+
+    /// Supported algorithms
+    pub algorithms: Vec<Algorithm>,
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -2,9 +2,13 @@
 
 pub(crate) mod commands;
 mod error;
-mod serial_number;
+mod info;
+pub(super) mod serial;
+pub(super) mod storage;
 
 pub use self::{
     error::{DeviceError, DeviceErrorKind},
-    serial_number::SerialNumber,
+    info::Info,
+    serial::Number as SerialNumber,
+    storage::Info as StorageInfo,
 };

--- a/src/device/serial.rs
+++ b/src/device/serial.rs
@@ -6,29 +6,29 @@ use std::{
     str::FromStr,
 };
 
-/// Length of a YubiHSM 2 serial number
-pub const SERIAL_DIGITS: usize = 10;
+/// Length of a YubiHSM 2 serial number in base 10 digits (i.e. characters)
+const DIGITS: usize = 10;
 
 /// YubiHSM serial numbers
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub struct SerialNumber(u32);
+pub struct Number(u32);
 
-impl Display for SerialNumber {
+impl Display for Number {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:0width$}", self.0, width = SERIAL_DIGITS)
+        write!(f, "{:0width$}", self.0, width = DIGITS)
     }
 }
 
-impl FromStr for SerialNumber {
+impl FromStr for Number {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<SerialNumber, Error> {
-        if s.len() == SERIAL_DIGITS {
-            Ok(SerialNumber(s.parse()?))
+    fn from_str(s: &str) -> Result<Number, Error> {
+        if s.len() == DIGITS {
+            Ok(Number(s.parse()?))
         } else {
             bail!(
                 "invalid serial number length (expected {}, got {}): '{}'",
-                SERIAL_DIGITS,
+                DIGITS,
                 s.len(),
                 s
             );

--- a/src/device/storage.rs
+++ b/src/device/storage.rs
@@ -1,0 +1,22 @@
+//! Information about device storage
+
+/// Response from the [Get Storage Info] command.
+///
+/// [Get Storage Info]: https://developers.yubico.com/YubiHSM2/Commands/Get_Storage_Info.html
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Info {
+    /// Total number of storage records
+    pub total_records: u16,
+
+    /// Storage records which are currently free
+    pub free_records: u16,
+
+    /// Total number of storage pages
+    pub total_pages: u16,
+
+    /// Storage pages which are currently free
+    pub free_pages: u16,
+
+    /// Page size in bytes
+    pub page_size: u16,
+}

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -14,7 +14,7 @@ use crate::{
     authentication::{self, commands::*},
     command::{Code, Message},
     connector::ConnectionError,
-    device::{commands::*, DeviceErrorKind, SerialNumber},
+    device::{self, commands::*, DeviceErrorKind, SerialNumber, StorageInfo},
     hmac::{self, commands::*},
     object::{self, commands::*},
     opaque::{self, commands::*},
@@ -155,7 +155,7 @@ fn delete_object(state: &mut State, cmd_data: &[u8]) -> response::Message {
 
 /// Generate a mock device information report
 fn device_info() -> response::Message {
-    DeviceInfoResponse {
+    let info = device::Info {
         major_version: 2,
         minor_version: 0,
         build_version: 0,
@@ -211,8 +211,9 @@ fn device_info() -> response::Message {
             Algorithm::Asymmetric(asymmetric::Algorithm::Ed25519),
             Algorithm::Asymmetric(asymmetric::Algorithm::EC_P224),
         ],
-    }
-    .serialize()
+    };
+
+    DeviceInfoResponse(info).serialize()
 }
 
 /// Echo a message back to the host
@@ -397,14 +398,15 @@ fn get_public_key(state: &State, cmd_data: &[u8]) -> response::Message {
 /// Generate a mock storage status report
 fn get_storage_info() -> response::Message {
     // TODO: model actual free storage
-    GetStorageInfoResponse {
+    let info = StorageInfo {
         total_records: 256,
         free_records: 256,
         total_pages: 1024,
         free_pages: 1024,
         page_size: 126,
-    }
-    .serialize()
+    };
+
+    GetStorageInfoResponse(info).serialize()
 }
 
 /// Import an object encrypted under a wrap key into the HSM

--- a/src/object/handle.rs
+++ b/src/object/handle.rs
@@ -3,7 +3,7 @@ use crate::object;
 /// Objects in the HSM are keyed by a tuple of their type an object::Id
 /// (i.e. multiple objects of different types can have the same object::Id)
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]
-pub(crate) struct Handle {
+pub struct Handle {
     /// ID of the object
     pub object_id: object::Id,
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -14,10 +14,10 @@ mod label;
 mod origins;
 mod types;
 
-pub(crate) use self::handle::Handle;
 pub use self::{
     entry::Entry,
     filter::Filter,
+    handle::Handle,
     info::Info,
     label::{Label, LABEL_SIZE},
     origins::Origin,

--- a/src/wrap/commands/import.rs
+++ b/src/wrap/commands/import.rs
@@ -28,7 +28,7 @@ impl Command for ImportWrappedCommand {
 
 /// Response from `command::import_wrapped`
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ImportWrappedResponse {
+pub(crate) struct ImportWrappedResponse {
     /// Type of object
     pub object_type: object::Type,
 


### PR DESCRIPTION
Factor the `device_info()` and `get_storage_info()`-related types into proper public types.

Also refactors `import_wrapped()` to return an `object::Handle`.