### PR TITLE
'rsa-preview' cargo feature, secp256k1 tests, doc fixups, audit test gating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
         name: clippy
         command: |
           cargo clippy --version
-          cargo clippy --features=rsa,usb
+          cargo clippy --features=rsa-preview,secp256k1,usb
           cargo clippy --features=mockhsm
     - run:
         name: build --no-default-features
@@ -45,11 +45,11 @@ jobs:
           cargo --version
           cargo build --release
     - run:
-        name: build --features=rsa
+        name: build --features=rsa-preview
         command: |
           rustc --version
           cargo --version
-          cargo build --features=rsa
+          cargo build --features=rsa-preview
     - run:
         name: build --features=usb
         command: |
@@ -67,7 +67,7 @@ jobs:
         command: |
           rustc --version
           cargo --version
-          cargo test --features=mockhsm,rsa
+          cargo test --features=mockhsm,rsa-preview,secp256k1
     - run:
         name: audit
         command: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,15 +58,16 @@ untrusted = "0.6"
 [features]
 default = ["http", "passwords", "setup", "signatory"]
 http = ["gaunt"]
+force-audit-test = [] # TODO(tarcieri): clear audit log when tests start. See notes on PR#185
 mockhsm = ["passwords", "ring", "untrusted"]
 nightly = ["subtle/nightly", "zeroize/nightly"]
 passwords = ["hmac", "pbkdf2", "sha2"]
-rsa = ["sha2"]
+rsa-preview = ["sha2"]
 setup = ["chrono", "passwords", "serde_json", "uuid/serde"]
 usb = ["lazy_static", "libusb"]
 
 [package.metadata.docs.rs]
-features = ["mockhsm", "rsa", "usb"]
+features = ["mockhsm", "rsa-preview", "secp256k1", "setup", "usb"]
 
 [[bench]]
 name = "ed25519"

--- a/src/asymmetric/mod.rs
+++ b/src/asymmetric/mod.rs
@@ -1,4 +1,4 @@
-//! Asymmetric cryptography (encryption/signatures) functionality
+//! Asymmetric cryptography i.e. digital signatures and public-key encryption
 
 mod algorithm;
 pub mod attestation;

--- a/src/asymmetric/rsa/mod.rs
+++ b/src/asymmetric/rsa/mod.rs
@@ -1,13 +1,18 @@
-//! RSA (Rivest–Shamir–Adleman) asymmetric cryptosystem support (signing/encryption)
+//! RSA (Rivest–Shamir–Adleman) asymmetric cryptosystem support
+//! (signing/encryption).
+//!
+//! NOTE: This functionality has not been properly tested and is therefore
+//! not enabled by default! Enable the `rsa-preview` cargo feature if you would
+//! like to use it (please report success or bugs!)
+
+// TODO(tarcieri): finalize and test RSA support
 
 mod algorithm;
 pub mod mgf;
 
-// TODO(tarcieri): finalize and test RSA support
-// Until then, it's gated behind the `rsa` feature
-#[cfg(feature = "rsa")]
+#[cfg(feature = "rsa-preview")]
 pub mod pkcs1;
-#[cfg(feature = "rsa")]
+#[cfg(feature = "rsa-preview")]
 pub mod pss;
 
 pub use self::algorithm::*;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     wrap::{self, commands::*},
 };
 use std::time::{Duration, Instant};
-#[cfg(feature = "rsa")]
+#[cfg(feature = "rsa-preview")]
 use {
     crate::asymmetric::rsa::{self, pkcs1::commands::*, pss::commands::*},
     byteorder::{BigEndian, ByteOrder},
@@ -834,7 +834,7 @@ impl Client {
     /// own risk!
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Pkcs1.html>
-    #[cfg(feature = "rsa")]
+    #[cfg(feature = "rsa-preview")]
     pub fn sign_rsa_pkcs1v15_sha256(
         &mut self,
         key_id: object::Id,
@@ -854,7 +854,7 @@ impl Client {
     /// own risk!
     ///
     /// <https://developers.yubico.com/YubiHSM2/Commands/Sign_Pss.html>
-    #[cfg(feature = "rsa")]
+    #[cfg(feature = "rsa-preview")]
     pub fn sign_rsa_pss_sha256(
         &mut self,
         key_id: object::Id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,11 @@
 //!
 //! # Getting Started
 //!
-//! The following documentation describes the most important parts of this crate's API:
+//! Most crate functionality can be found in the `Client` type:
 //!
-//! * [yubihsm::connector]: methods of connecting to a YubiHSM (USB or HTTP via [yubihsm-connector])
-//! * [yubihsm::Client]: client providing wrappers for YubiHSM [commands].
+//! * [yubihsm::Client: main API for all YubiHSM functionality! Start here!][yubihsm::Client]
+//!
+//! In order to connect to the HSM, you'll need to make a [yubihsm::Connector].
 //!
 //! # Example
 //!
@@ -46,7 +47,7 @@
 //! println!("Ed25519 signature: {:?}", signature);
 //! ```
 //!
-//! [yubihsm::connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/index.html
+//! [yubihsm::Connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html
 //! [yubihsm::Client]: https://docs.rs/yubihsm/latest/yubihsm/client/struct.Client.html
 //! [commands]: https://developers.yubico.com/YubiHSM2/Commands/
 //! [yubihsm-connector]: https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/

--- a/tests/command/set_option.rs
+++ b/tests/command/set_option.rs
@@ -20,6 +20,8 @@ fn command_audit_options_test() {
 }
 
 /// Configure the "force audit" option setting
+// TODO(tarcieri): clear audit log when tests start. See notes on PR#185
+#[cfg(feature = "force-audit-test")]
 #[test]
 fn force_audit_option_test() {
     let mut client = crate::get_hsm_client();


### PR DESCRIPTION
- Renames the RSA cargo feature to `rsa-preview` to note its instability.
- Enables secp256k1 crate in testing and docs.
- Overall doc improvements.
- Gate audit option testing on a cargo feature, since when tests explode it can leave the HSM in a bad state (audit log full).

NOTE: The latter could probably be addressed by clearing the audit log when the tests start. This is noted in a comment.