### PR TITLE
README.md+connector*.rs: Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ This is a pure-Rust client library for [YubiHSM 2] devices which implements
 most the functionality of the [libyubihsm] C library from Yubico's YubiHSM SDK.
 It provides two backends for communicating with YubiHSMs:
 
-- [yubihsm::HttpConnector]: communicate with YubiHSM via the
-  `yubihsm-connector` process from the Yubico SDK.
-- [yubihsm::UsbConnector]: communicate directly with the YubiHSM over USB using
+- [HTTP][http-connector]: communicate with YubiHSM via the `yubihsm-connector`
+  process from the Yubico SDK.
+- [USB][usb-connector]: communicate directly with the YubiHSM over USB using
   the [libusb] crate.
 
 The [yubihsm::Client] type provides access to [HSM commands][command].
@@ -143,8 +143,8 @@ WHICH CONTAINS KEYS YOU CARE ABOUT**
 
 ### `cargo test --features=usb`: test YubiHSM2 live via USB
 
-Adding the `usb` cargo feature builds `UsbConnector` in addition to
-`HttpConnector`, and also runs the test suite live via USB rather than using
+Adding the `usb` cargo feature builds in USB connector support in addition to
+HTTP connector, and also runs the test suite live via USB rather than using
 the `yubihsm-connector` process.
 
 **ALSO NOTE THAT THESE TESTS ARE DESTRUCTIVE: DO NOT RUN THEM AGAINST A
@@ -166,8 +166,8 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [YubiHSM 2]: https://www.yubico.com/products/yubihsm/
 [Yubico]: https://www.yubico.com/
 [yubihsm-connector]: https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/
-[yubihsm::HttpConnector]: https://docs.rs/yubihsm/latest/yubihsm/connector/http/struct.HttpConnector.html
-[yubihsm::UsbConnector]: https://docs.rs/yubihsm/latest/yubihsm/connector/usb/struct.UsbConnector.html
+[http-connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.http
+[usb-connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.usb
 [yubihsm::Client]: https://docs.rs/yubihsm/latest/yubihsm/client/struct.Client.html
 [command]: https://developers.yubico.com/YubiHSM2/Commands/
 [libusb]: https://github.com/dcuddeback/libusb-rs

--- a/src/connector/mod.rs
+++ b/src/connector/mod.rs
@@ -1,14 +1,17 @@
 //! Methods of connecting to a YubiHSM 2:
 //!
-//! - [HttpConnector]: communicates with HSM via the `yubihsm-connector` service's HTTP API
-//! - [UsbConnector]: communicates with the HSM directly via USB using `libusb`.
+//! - [HTTP][http-connector]: communicate with YubiHSM via the `yubihsm-connector`
+//!   process from the Yubico SDK.
+//! - [USB][usb-connector]: communicate directly with the YubiHSM over USB using
+//!   the [libusb] crate.
 //!
-//! Additionally, [MockHsm] implements the `Connector` API and can be used as a drop-in replacement
-//! in places where you would like a simulated HSM for testing (e.g. CI).
+//! Additionally, this crate includes an optional development-only [mockhsm]
+//! (gated under a `mockhsm` cargo feature) which can be used as a drop-in
+//! replacement in places where you would like a simulated HSM for testing (e.g. CI).
 //!
-//! [HttpConnector]: https://docs.rs/yubihsm/latest/yubihsm/connector/http/struct.HttpConnector.html
-//! [UsbConnector]: https://docs.rs/yubihsm/latest/yubihsm/connector/usb/struct.UsbConnector.html
-//! [MockHsm]: https://docs.rs/yubihsm/latest/yubihsm/mockhsm/struct.MockHsm.html
+//! [http-connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.http
+//! [usb-connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.usb
+//! [mockhsm]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.mockhsm
 
 #[macro_use]
 mod error;
@@ -56,7 +59,11 @@ impl Connector {
         Self::from(HttpConnector::create(config))
     }
 
-    /// Create a new USB connector
+    /// Create a new USB connector. For more advanced usage including
+    /// connecting to multiple YubiHSMs over USB which are plugged into
+    /// the same computer, please see the [yubihsm::connector::usb] module.
+    ///
+    /// [yubihsm::connector::usb]: https://docs.rs/yubihsm/latest/yubihsm/connector/usb/index.html
     #[cfg(feature = "usb")]
     pub fn usb(config: &UsbConfig) -> Self {
         Self::from(UsbConnector::create(config))

--- a/src/connector/usb/mod.rs
+++ b/src/connector/usb/mod.rs
@@ -1,4 +1,6 @@
-//! Support for connecting to the YubiHSM 2 via USB
+//! Support for connecting to the YubiHSM 2 via USB.
+//!
+//! The [yubihsm::connector::usb::Devices] can be used to
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
There were a lot of dead links and incorrect information still in the docs after the recent connector changes. This commit updates/fixes them.