### PR TITLE
Make yubihsm::client::Client thread-safe

### DIFF
--- a/src/session/guard.rs
+++ b/src/session/guard.rs
@@ -1,0 +1,33 @@
+//! MutexGuard wrapper protecting an optional session which is always true
+
+use super::Session;
+use std::ops::{Deref, DerefMut};
+use std::sync::MutexGuard;
+
+/// Mutex-guarded wrapper type containing a locked session
+pub struct Guard<'mutex>(MutexGuard<'mutex, Option<Session>>);
+
+impl<'mutex> Guard<'mutex> {
+    /// Create a session guard from a `MutexGuard`ed `Session`
+    pub(crate) fn new(mutex_guard: MutexGuard<'mutex, Option<Session>>) -> Self {
+        assert!(
+            mutex_guard.is_some(),
+            "session::Guard must wrap an active session"
+        );
+        Guard(mutex_guard)
+    }
+}
+
+impl<'mutex> Deref for Guard<'mutex> {
+    type Target = Session;
+
+    fn deref(&self) -> &Session {
+        self.0.deref().as_ref().unwrap()
+    }
+}
+
+impl<'mutex> DerefMut for Guard<'mutex> {
+    fn deref_mut(&mut self) -> &mut Session {
+        self.0.deref_mut().as_mut().unwrap()
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -8,12 +8,14 @@ mod macros;
 
 pub(crate) mod commands;
 mod error;
+mod guard;
 mod id;
 pub(crate) mod securechannel;
 mod timeout;
 
 pub use self::{
     error::{SessionError, SessionErrorKind},
+    guard::Guard,
     id::Id,
     timeout::Timeout,
 };

--- a/tests/command/blink_device.rs
+++ b/tests/command/blink_device.rs
@@ -1,6 +1,6 @@
 /// Blink the LED on the YubiHSM for 2 seconds
 #[test]
 fn blink_device_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     client.blink_device(2).unwrap();
 }

--- a/tests/command/delete_object.rs
+++ b/tests/command/delete_object.rs
@@ -4,10 +4,10 @@ use yubihsm::{asymmetric, object, Capability};
 /// Delete an object in the YubiHSM 2
 #[test]
 fn delete_object_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     generate_asymmetric_key(
-        &mut client,
+        &client,
         asymmetric::Algorithm::Ed25519,
         Capability::SIGN_EDDSA,
     );

--- a/tests/command/device_info.rs
+++ b/tests/command/device_info.rs
@@ -1,7 +1,7 @@
 /// Get device information
 #[test]
 fn device_info_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let device_info = client
         .device_info()

--- a/tests/command/echo.rs
+++ b/tests/command/echo.rs
@@ -3,7 +3,7 @@ use TEST_MESSAGE;
 /// Send a simple echo request
 #[test]
 fn echo_test() {
-    let mut client = crate::create_client();
+    let client = crate::create_client();
 
     let echo_response = client.echo(TEST_MESSAGE)
         .unwrap_or_else(|err| panic!("error sending echo: {}", err));

--- a/tests/command/export_wrapped.rs
+++ b/tests/command/export_wrapped.rs
@@ -8,12 +8,12 @@ use yubihsm::{asymmetric, object, wrap, Capability};
 // TODO: test against RFC 3610 vectors
 #[test]
 fn wrap_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     let algorithm = wrap::Algorithm::AES128_CCM;
     let capabilities = Capability::EXPORT_WRAPPED | Capability::IMPORT_WRAPPED;
     let delegated_capabilities = Capability::all();
 
-    clear_test_key_slot(&mut client, object::Type::WrapKey);
+    clear_test_key_slot(&client, object::Type::WrapKey);
 
     let key_id = client
         .put_wrap_key(

--- a/tests/command/generate_asymmetric_key.rs
+++ b/tests/command/generate_asymmetric_key.rs
@@ -4,12 +4,12 @@ use yubihsm::{asymmetric, object, Capability};
 /// Generate an Ed25519 key
 #[test]
 fn ed25519_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let algorithm = asymmetric::Algorithm::Ed25519;
     let capabilities = Capability::SIGN_EDDSA;
 
-    generate_asymmetric_key(&mut client, algorithm, capabilities);
+    generate_asymmetric_key(&client, algorithm, capabilities);
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::AsymmetricKey)
@@ -28,11 +28,11 @@ fn ed25519_key_test() {
 #[cfg(not(feature = "mockhsm"))]
 #[test]
 fn nistp256_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     let algorithm = asymmetric::Algorithm::EC_P256;
     let capabilities = Capability::SIGN_EDDSA;
 
-    generate_asymmetric_key(&mut client, algorithm, capabilities);
+    generate_asymmetric_key(&client, algorithm, capabilities);
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::AsymmetricKey)

--- a/tests/command/generate_hmac_key.rs
+++ b/tests/command/generate_hmac_key.rs
@@ -4,12 +4,12 @@ use yubihsm::{hmac, object, Capability};
 /// Generate an HMAC key
 #[test]
 fn hmac_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let algorithm = hmac::Algorithm::SHA256;
     let capabilities = Capability::SIGN_HMAC | Capability::VERIFY_HMAC;
 
-    clear_test_key_slot(&mut client, object::Type::HmacKey);
+    clear_test_key_slot(&client, object::Type::HmacKey);
 
     let key_id = client
         .generate_hmac_key(

--- a/tests/command/generate_wrap_key.rs
+++ b/tests/command/generate_wrap_key.rs
@@ -4,7 +4,7 @@ use yubihsm::{object, wrap, Capability};
 /// Generate an AES-CCM key wrapping key
 #[test]
 fn wrap_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let algorithm = wrap::Algorithm::AES256_CCM;
     let capabilities = Capability::EXPORT_WRAPPED
@@ -13,7 +13,7 @@ fn wrap_key_test() {
         | Capability::WRAP_DATA;
     let delegated_capabilities = Capability::all();
 
-    clear_test_key_slot(&mut client, object::Type::WrapKey);
+    clear_test_key_slot(&client, object::Type::WrapKey);
 
     let key_id = client
         .generate_wrap_key(

--- a/tests/command/get_log_entries.rs
+++ b/tests/command/get_log_entries.rs
@@ -1,7 +1,7 @@
 /// Get audit log
 #[test]
 fn get_audit_logs_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     // TODO: test audit logging functionality
     client

--- a/tests/command/get_object_info.rs
+++ b/tests/command/get_object_info.rs
@@ -7,7 +7,7 @@ use yubihsm::{
 /// Get object info on default auth key
 #[test]
 fn default_authkey_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let object_info = client
         .get_object_info(

--- a/tests/command/get_option.rs
+++ b/tests/command/get_option.rs
@@ -1,7 +1,7 @@
 /// Get the auditing options for all commands
 #[test]
 fn command_audit_options_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let results = client
         .get_commands_audit_options()
@@ -13,7 +13,7 @@ fn command_audit_options_test() {
 /// Get the "force audit" option setting
 #[test]
 fn force_audit_option_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     client
         .get_force_audit_option()

--- a/tests/command/get_pseudo_random.rs
+++ b/tests/command/get_pseudo_random.rs
@@ -1,7 +1,7 @@
 /// Get random bytes
 #[test]
 fn get_pseudo_random_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let bytes = client
         .get_pseudo_random(32)

--- a/tests/command/get_storage_info.rs
+++ b/tests/command/get_storage_info.rs
@@ -1,7 +1,7 @@
 /// Get stats about currently free storage
 #[test]
 fn get_storage_info_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let response = client
         .get_storage_info()

--- a/tests/command/list_objects.rs
+++ b/tests/command/list_objects.rs
@@ -4,10 +4,10 @@ use yubihsm::{asymmetric, object, Capability};
 /// List the objects in the YubiHSM 2
 #[test]
 fn list_objects_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     generate_asymmetric_key(
-        &mut client,
+        &client,
         asymmetric::Algorithm::Ed25519,
         Capability::SIGN_EDDSA,
     );
@@ -26,7 +26,7 @@ fn list_objects_test() {
 /// Filter objects in the HSM by their type
 #[test]
 fn list_objects_with_filter() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     let objects = client
         .list_objects(&[object::Filter::Type(object::Type::AuthenticationKey)])

--- a/tests/command/put_asymmetric_key.rs
+++ b/tests/command/put_asymmetric_key.rs
@@ -6,12 +6,12 @@ use crate::{put_asymmetric_key, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL};
 /// Put an Ed25519 key
 #[test]
 fn ed25519_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     let algorithm = asymmetric::Algorithm::Ed25519;
     let capabilities = Capability::SIGN_EDDSA;
     let example_private_key = ED25519_TEST_VECTORS[0].sk;
 
-    put_asymmetric_key(&mut client, algorithm, capabilities, example_private_key);
+    put_asymmetric_key(&client, algorithm, capabilities, example_private_key);
 
     let object_info = client
         .get_object_info(TEST_KEY_ID, object::Type::AsymmetricKey)

--- a/tests/command/put_authentication_key.rs
+++ b/tests/command/put_authentication_key.rs
@@ -5,12 +5,12 @@ use crate::{clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL, TEST
 /// Put a new authentication key into the `YubiHSM`
 #[test]
 fn put_authentication_key() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     let algorithm = authentication::Algorithm::YUBICO_AES;
     let capabilities = Capability::all();
     let delegated_capabilities = Capability::all();
 
-    clear_test_key_slot(&mut client, object::Type::AuthenticationKey);
+    clear_test_key_slot(&client, object::Type::AuthenticationKey);
 
     let new_authentication_key = authentication::Key::derive_from_password(TEST_MESSAGE);
 

--- a/tests/command/put_opaque.rs
+++ b/tests/command/put_opaque.rs
@@ -5,9 +5,9 @@ use crate::{clear_test_key_slot, TEST_DOMAINS, TEST_KEY_ID, TEST_KEY_LABEL, TEST
 /// Put an opaque object and read it back
 #[test]
 fn opaque_object_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
-    clear_test_key_slot(&mut client, object::Type::Opaque);
+    clear_test_key_slot(&client, object::Type::Opaque);
 
     let object_id = client
         .put_opaque(

--- a/tests/command/reset_device.rs
+++ b/tests/command/reset_device.rs
@@ -1,6 +1,6 @@
 /// Reset the YubiHSM 2 to a factory default state
 #[test]
 fn reset_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     client.reset_device().unwrap();
 }

--- a/tests/command/set_option.rs
+++ b/tests/command/set_option.rs
@@ -3,7 +3,7 @@ use yubihsm::{command, AuditOption};
 /// Set the auditing options for a particular command
 #[test]
 fn command_audit_options_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     let command_type = command::Code::Echo;
 
     for audit_option in &[AuditOption::On, AuditOption::Off] {
@@ -24,7 +24,7 @@ fn command_audit_options_test() {
 #[cfg(feature = "force-audit-test")]
 #[test]
 fn force_audit_option_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     // Make sure we've consumed the latest log data or else forced auditing
     // will prevent the tests from completing

--- a/tests/command/sign_attestation_certificate.rs
+++ b/tests/command/sign_attestation_certificate.rs
@@ -4,10 +4,10 @@ use yubihsm::{asymmetric, Capability};
 /// Generate an attestation about a key in the HSM
 #[test]
 fn attest_asymmetric_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     generate_asymmetric_key(
-        &mut client,
+        &client,
         asymmetric::Algorithm::EC_P256,
         Capability::SIGN_ECDSA,
     );

--- a/tests/command/sign_ecdsa.rs
+++ b/tests/command/sign_ecdsa.rs
@@ -7,10 +7,10 @@ use yubihsm::{asymmetric, Capability};
 /// Test ECDSA signatures (using NIST P-256)
 #[test]
 fn generated_nistp256_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     generate_asymmetric_key(
-        &mut client,
+        &client,
         asymmetric::Algorithm::EC_P256,
         Capability::SIGN_ECDSA,
     );

--- a/tests/command/sign_eddsa.rs
+++ b/tests/command/sign_eddsa.rs
@@ -9,11 +9,11 @@ use yubihsm::{asymmetric, Capability};
 /// Test Ed25519 against RFC 8032 test vectors
 #[test]
 fn test_vectors() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     for vector in ED25519_TEST_VECTORS {
         put_asymmetric_key(
-            &mut client,
+            &client,
             asymmetric::Algorithm::Ed25519,
             Capability::SIGN_EDDSA,
             vector.sk,
@@ -37,10 +37,10 @@ fn test_vectors() {
 /// Test Ed25519 signing using a randomly generated HSM key
 #[test]
 fn generated_key_test() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
 
     generate_asymmetric_key(
-        &mut client,
+        &client,
         asymmetric::Algorithm::Ed25519,
         Capability::SIGN_EDDSA,
     );

--- a/tests/command/verify_hmac.rs
+++ b/tests/command/verify_hmac.rs
@@ -7,12 +7,12 @@ use yubihsm::{hmac, Capability};
 /// Test HMAC against RFC 4231 test vectors
 #[test]
 fn hmac_test_vectors() {
-    let mut client = crate::get_hsm_client();
+    let client = crate::get_hsm_client();
     let algorithm = hmac::Algorithm::SHA256;
     let capabilities = Capability::SIGN_HMAC | Capability::VERIFY_HMAC;
 
     for vector in HMAC_SHA256_TEST_VECTORS {
-        clear_test_key_slot(&mut client, object::Type::HmacKey);
+        clear_test_key_slot(&client, object::Type::HmacKey);
 
         let key_id = client
             .put_hmac_key(

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -33,17 +33,13 @@ fn create_signer<C>(key_id: object::Id) -> ecdsa::Signer<C>
 where
     C: WeierstrassCurve,
 {
-    let mut client = Client::open(crate::HSM_CONNECTOR.clone(), Default::default(), true).unwrap();
-    create_yubihsm_key(&mut client, key_id, ecdsa::Signer::<C>::asymmetric_alg());
-    ecdsa::Signer::create(client, key_id).unwrap()
+    let client = crate::get_hsm_client();
+    create_yubihsm_key(&client, key_id, ecdsa::Signer::<C>::asymmetric_alg());
+    ecdsa::Signer::create(client.clone(), key_id).unwrap()
 }
 
 /// Create the key on the YubiHSM to use for this test
-fn create_yubihsm_key(
-    client: &mut Client,
-    key_id: object::Id,
-    alg: yubihsm::asymmetric::Algorithm,
-) {
+fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmetric::Algorithm) {
     // Delete the key in TEST_KEY_ID slot it exists
     // Ignore errors since the object may not exist yet
     let _ = client.delete_object(key_id, yubihsm::object::Type::AsymmetricKey);

--- a/tests/ed25519/mod.rs
+++ b/tests/ed25519/mod.rs
@@ -20,7 +20,7 @@ const TEST_MESSAGE: &[u8] =
         variant of Schnorr's signature system with (possibly twisted) Edwards curves.";
 
 /// Create the key on the YubiHSM to use for this test
-fn create_yubihsm_key(client: &mut Client) {
+fn create_yubihsm_key(client: &Client) {
     // Delete the key in TEST_KEY_ID slot it exists
     // Ignore errors since the object may not exist yet
     let _ = client.delete_object(TEST_SIGNING_KEY_ID, yubihsm::object::Type::AsymmetricKey);
@@ -39,10 +39,10 @@ fn create_yubihsm_key(client: &mut Client) {
 
 #[test]
 fn ed25519_sign_test() {
-    let mut client = Client::open(crate::HSM_CONNECTOR.clone(), Default::default(), true).unwrap();
-    create_yubihsm_key(&mut client);
+    let client = crate::get_hsm_client();
+    create_yubihsm_key(&client);
 
-    let signer = ed25519::Signer::create(client, TEST_SIGNING_KEY_ID).unwrap();
+    let signer = ed25519::Signer::create(client.clone(), TEST_SIGNING_KEY_ID).unwrap();
     let signature = signer.sign(TEST_MESSAGE).unwrap();
     let verifier = Ed25519Verifier::from(&signer.public_key().unwrap());
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -107,7 +107,7 @@ pub fn create_mockhsm_connector() -> Connector {
 }
 
 /// Delete the key in the test key slot (if it exists, otherwise do nothing)
-pub fn clear_test_key_slot(client: &mut Client, object_type: object::Type) {
+pub fn clear_test_key_slot(client: &Client, object_type: object::Type) {
     println!("clearing test key slot: {:?} {}", object_type, TEST_KEY_ID);
 
     // Delete the key in TEST_KEY_ID slot it exists (we use it for testing)
@@ -132,7 +132,7 @@ pub fn clear_test_key_slot(client: &mut Client, object_type: object::Type) {
 
 /// Create a public key for use in a test
 pub fn generate_asymmetric_key(
-    client: &mut Client,
+    client: &Client,
     algorithm: asymmetric::Algorithm,
     capabilities: Capability,
 ) {
@@ -152,7 +152,7 @@ pub fn generate_asymmetric_key(
 
 /// Put an asymmetric private key into the HSM
 pub fn put_asymmetric_key<T: Into<Vec<u8>>>(
-    client: &mut Client,
+    client: &Client,
     algorithm: asymmetric::Algorithm,
     capabilities: Capability,
     data: T,


### PR DESCRIPTION
Wraps the internal session in an `Arc<Mutex<_>>`, which is held whenever communicating with the HSM (or attempting to connect).

This eliminates the need for the Signatory signers types to each do this themselves internally.

This makes `yubihsm::client::Client` Clone-able, and eliminates the need to take a `&mut` reference to it whenever making any calls to it.