### PR TITLE
v0.22.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [0.22.0] (2019-03-24)
+
+- Integrate Signatory types ([#192])
+- Make `yubihsm::client::Client` thread-safe ([#191])
+- Move asymmetric algorithm modules into the toplevel ([#190])
+- Fix parsing of wrap nonces ([#188])
+- Make signatory a mandatory dependency ([#186])
+- `rsa-preview` cargo feature ([#185])
+- Factor device info/storage/wrap commands into public types ([#184])
+
 ## [0.21.0] (2019-02-26)
 
 - Factor algorithms into their own Rust modules ([#180])
@@ -213,6 +223,14 @@ to adding support for several commands.
 
 - Initial release
 
+[0.22.0]: https://github.com/tendermint/yubihsm-rs/pull/194
+[#192]: https://github.com/tendermint/yubihsm-rs/pull/192
+[#191]: https://github.com/tendermint/yubihsm-rs/pull/191
+[#190]: https://github.com/tendermint/yubihsm-rs/pull/190
+[#188]: https://github.com/tendermint/yubihsm-rs/pull/188
+[#186]: https://github.com/tendermint/yubihsm-rs/pull/186
+[#185]: https://github.com/tendermint/yubihsm-rs/pull/185
+[#184]: https://github.com/tendermint/yubihsm-rs/pull/184
 [0.21.0]: https://github.com/tendermint/yubihsm-rs/pull/183
 [#180]: https://github.com/tendermint/yubihsm-rs/pull/180
 [#179]: https://github.com/tendermint/yubihsm-rs/pull/179

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 USB-based access to the device. Supports most HSM functionality
                 including ECDSA, Ed25519, HMAC, and RSA.
                 """
-version       = "0.22.0-alpha2" # Also update html_root_url in lib.rs when bumping this
+version       = "0.22.0" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docs][docs-image]][docs-link]
 ![MIT/Apache2 licensed][license-image]
 [![Build Status][build-image]][build-link]
-<img src="https://rustsec.org/assets/img/badges/unsafe/deny.svg" width="88" height="20" alt="unsafe: deny">
+<img src="https://rustsec.org/assets/img/badges/unsafe/forbidden.svg" height="20" alt="unsafe: forbidden">
 
 [crate-image]: https://img.shields.io/crates/v/yubihsm.svg
 [crate-link]: https://crates.io/crates/yubihsm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/master/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.22.0-alpha2"
+    html_root_url = "https://docs.rs/yubihsm/0.22.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Integrate Signatory types (#192)
- Make `yubihsm::client::Client` thread-safe (#191)
- Move asymmetric algorithm modules into the toplevel (#190)
- Fix parsing of wrap nonces (#188)
- Make signatory a mandatory dependency (#186)
- `rsa-preview` cargo feature (#185)
- Factor device info/storage/wrap commands into public types (#184)