### PR TITLE
Switch from rand_os to getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ cmac = "0.2"
 failure = "0.1"
 failure_derive = "0.1"
 gaunt = { version = "0.1", optional = true }
+getrandom = "0.1"
 hmac = { version = "0.7", optional = true }
 lazy_static = { version = "1", optional = true }
 libusb = { version = "0.3", optional = true }
 log = "0.4"
 pbkdf2 = { version = "0.3", optional = true, default-features = false }
-rand_os = "0.1"
 serde = "1"
 serde_derive = "1"
 serde_json = { version = "1", optional = true }
@@ -60,7 +60,6 @@ default = ["http", "passwords", "setup"]
 http = ["gaunt"]
 force-audit-test = [] # TODO(tarcieri): clear audit log when tests start. See notes on PR#185
 mockhsm = ["passwords", "ring", "untrusted"]
-nightly = ["subtle/nightly", "zeroize/nightly"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 rsa-preview = ["sha2"]
 setup = ["chrono", "passwords", "serde_json", "uuid/serde"]

--- a/src/authentication/key.rs
+++ b/src/authentication/key.rs
@@ -1,11 +1,11 @@
 //! `YubiHSM 2` authentication keys (2 * AES-128 symmetric PSK) from which session keys are derived
 
 use super::{KeyError, KeyErrorKind};
+use getrandom::getrandom;
 #[cfg(feature = "hmac")]
 use hmac_crate::Hmac;
 #[cfg(feature = "pbkdf2")]
 use pbkdf2::pbkdf2;
-use rand_os::{rand_core::RngCore, OsRng};
 #[cfg(feature = "sha2")]
 use sha2::Sha256;
 use std::fmt::{self, Debug};
@@ -34,9 +34,8 @@ pub struct Key(pub(crate) [u8; SIZE]);
 impl Key {
     /// Generate a random `Key` using `OsRng`.
     pub fn random() -> Self {
-        let mut rng = OsRng::new().expect("RNG failure!");
         let mut challenge = [0u8; SIZE];
-        rng.fill_bytes(&mut challenge);
+        getrandom(&mut challenge).expect("RNG failure!");
         Key(challenge)
     }
 

--- a/src/mockhsm/command.rs
+++ b/src/mockhsm/command.rs
@@ -24,8 +24,8 @@ use crate::{
     wrap::{self, commands::*},
     Capability,
 };
+use getrandom::getrandom;
 use hmac_crate::{Hmac, Mac};
-use rand_os::{rand_core::RngCore, OsRng};
 use ring::signature::Ed25519KeyPair;
 use sha2::Sha256;
 use std::{io::Cursor, str::FromStr};
@@ -366,9 +366,8 @@ fn get_pseudo_random(_state: &State, cmd_data: &[u8]) -> response::Message {
     let command: GetPseudoRandomCommand = deserialize(cmd_data)
         .unwrap_or_else(|e| panic!("error parsing Code::GetPseudoRandom: {:?}", e));
 
-    let mut rng = OsRng::new().unwrap();
     let mut bytes = vec![0u8; command.bytes as usize];
-    rng.fill_bytes(&mut bytes[..]);
+    getrandom(&mut bytes).expect("RNG failure!");
 
     GetPseudoRandomResponse { bytes }.serialize()
 }

--- a/src/mockhsm/state.rs
+++ b/src/mockhsm/state.rs
@@ -49,7 +49,7 @@ impl State {
         host_challenge: Challenge,
     ) -> &HsmSession {
         // Generate a random card challenge to send back to the client
-        let card_challenge = Challenge::random();
+        let card_challenge = Challenge::new();
 
         let session_id = self
             .sessions

--- a/src/session/securechannel/challenge.rs
+++ b/src/session/securechannel/challenge.rs
@@ -1,7 +1,6 @@
-use rand_os::{
-    rand_core::{CryptoRng, RngCore},
-    OsRng,
-};
+//! Challenge messages used as part of SCP03's challenge/response protocol.
+
+use getrandom::getrandom;
 
 /// Size of a challenge message
 pub const CHALLENGE_SIZE: usize = 8;
@@ -11,15 +10,10 @@ pub const CHALLENGE_SIZE: usize = 8;
 pub struct Challenge([u8; CHALLENGE_SIZE]);
 
 impl Challenge {
-    /// Generate a random Challenge using OsRng
-    pub fn random() -> Self {
-        Self::new(&mut OsRng::new().expect("RNG failure!"))
-    }
-
-    /// Create a new Challenge using the given RNG
-    pub fn new<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+    /// Create a new random `Challenge`
+    pub fn new() -> Self {
         let mut challenge = [0u8; CHALLENGE_SIZE];
-        rng.fill_bytes(&mut challenge);
+        getrandom(&mut challenge).expect("RNG failure!");
         Challenge(challenge)
     }
 

--- a/src/session/securechannel/mod.rs
+++ b/src/session/securechannel/mod.rs
@@ -103,7 +103,7 @@ impl SecureChannel {
         connector: &Connector,
         credentials: &Credentials,
     ) -> Result<Self, SessionError> {
-        let host_challenge = Challenge::random();
+        let host_challenge = Challenge::new();
 
         let command_message: command::Message = CreateSessionCommand {
             authentication_key_id: credentials.authentication_key_id,

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,17 +1,13 @@
 //! UUID functionality
 
-extern crate uuid as uuid_crate;
-
-pub use uuid_crate::Uuid;
-
-use rand_os::{rand_core::RngCore, OsRng};
-use uuid_crate::{Builder, Variant, Version};
+use getrandom::getrandom;
+pub use uuid::Uuid;
+use uuid::{Builder, Variant, Version};
 
 /// Create a random UUID
 pub fn new_v4() -> Uuid {
-    let mut rng = OsRng::new().unwrap();
     let mut bytes = [0; 16];
-    rng.fill_bytes(&mut bytes);
+    getrandom(&mut bytes).expect("RNG failure!");
 
     Builder::from_bytes(bytes)
         .set_variant(Variant::RFC4122)

--- a/src/wrap/key.rs
+++ b/src/wrap/key.rs
@@ -11,7 +11,7 @@ use crate::{
     device::{DeviceError, DeviceErrorKind::*},
     object, wrap, Capability, Client, Domain,
 };
-use rand_os::{rand_core::RngCore, OsRng};
+use getrandom::getrandom;
 use std::fmt::{self, Debug};
 use zeroize::Zeroize;
 
@@ -31,9 +31,8 @@ pub struct Key {
 impl Key {
     /// Generate a random wrap key with the given key size.
     pub fn generate_random(key_id: object::Id, algorithm: wrap::Algorithm) -> Self {
-        let mut rand = OsRng::new().unwrap();
         let mut bytes = vec![0u8; algorithm.key_len()];
-        rand.fill_bytes(&mut bytes);
+        getrandom(&mut bytes).expect("RNG failure!");
 
         let result = Self::from_bytes(key_id, &bytes).unwrap();
         bytes.zeroize();

--- a/src/wrap/nonce.rs
+++ b/src/wrap/nonce.rs
@@ -1,7 +1,7 @@
 //! Nonces used by the YubiHSM 2's AES-CCM encrypted `wrap::Message`
 
 #[cfg(feature = "mockhsm")]
-use rand_os::{rand_core::RngCore, OsRng};
+use getrandom::getrandom;
 
 /// Number of bytes in a nonce used for "wrapping" (i.e AES-CCM encryption)
 pub const SIZE: usize = 13;
@@ -14,9 +14,8 @@ impl Nonce {
     /// Generate a random `wrap::Nonce`
     #[cfg(feature = "mockhsm")]
     pub fn generate() -> Self {
-        let mut rand = OsRng::new().unwrap();
         let mut bytes = [0u8; SIZE];
-        rand.fill_bytes(&mut bytes);
+        getrandom(&mut bytes).expect("RNG failure!");
         Nonce(bytes)
     }
 }


### PR DESCRIPTION
`rand_os` is now a wrapper for `getrandom` which includes some fallback implementations which are somewhat questionable.

Issues are being worked on upstream, but in the meantime the creators of `rand_os` spun the "thinnest possible wrapper to the OS's CSPRNG" functionality into `getrandom`.