### PR TITLE
setup: Support for (optionally) skipping initial device reset

### DIFF
--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -5,26 +5,11 @@ pub mod report;
 mod role;
 
 pub use self::{profile::Profile, report::Report, role::Role};
-
 use crate::{
     authentication::{self, Credentials, DEFAULT_AUTHENTICATION_KEY_ID},
     object, Capability, Client, Connector, Domain,
 };
 use failure::Error;
-use std::{
-    thread,
-    time::{Duration, SystemTime},
-};
-
-/// How long to initially wait for a device reset to complete
-const DEVICE_RESET_WAIT_MS: u64 = 1000;
-
-/// How frequently to poll the device in milliseconds after it's been reset
-const DEVICE_POLL_INTERVAL_MS: u64 = 250;
-
-/// Should we enable device reconnect during reset?
-/// Disabled to ensure that reconnecting doesn't gloss over anything important
-const ENABLE_RECONNECT_DURING_RESET: bool = false;
 
 /// Label to place on the temporary setup auth key ID
 const SETUP_KEY_LABEL: &str = "yubihsm.rs temporary setup key";
@@ -36,36 +21,48 @@ pub fn erase_device_and_init_with_profile(
     credentials: Credentials,
     profile: Profile,
 ) -> Result<Report, Error> {
-    let setup_auth_key_id = profile.setup_auth_key_id.ok_or_else(|| {
-        format_err!(
-            "profile setup_auth_key_id must be set when using erase_device_and_init_with_profile"
-        )
-    })?;
+    // Reset the device
+    let client = Client::open(connector.clone(), credentials, false)?
+        .reset_device_and_reconnect(profile.reset_device_timeout)?;
+
+    init_with_profile(client, profile)
+}
+
+/// Initialize an HSM device with the given profile.
+///
+/// This approach does not erase the device first, but generally assumes
+/// the HSM is in a clean state.
+///
+/// The recommended approach is to use `erase_device_and_init_with_profile`
+pub fn init_with_profile(client: Client, profile: Profile) -> Result<Report, Error> {
+    let setup_auth_key_id = profile
+        .setup_auth_key_id
+        .ok_or_else(|| format_err!("profile setup_auth_key_id unset!"))?;
 
     let temp_auth_key = authentication::Key::random();
 
-    // Reset the device and use the new session with default credentials
-    // to install the temporary setup authentication key
-    perform_device_reset(connector.clone(), credentials, profile.reset_device_timeout)?
-        .put_authentication_key(
-            setup_auth_key_id,
-            SETUP_KEY_LABEL.into(),
-            Domain::all(),
-            Capability::all(),
-            Capability::all(),
-            authentication::Algorithm::YUBICO_AES,
-            temp_auth_key.clone(),
-        )?;
+    client.put_authentication_key(
+        setup_auth_key_id,
+        SETUP_KEY_LABEL.into(),
+        Domain::all(),
+        Capability::all(),
+        Capability::all(),
+        authentication::Algorithm::YUBICO_AES,
+        temp_auth_key.clone(),
+    )?;
 
     info!(
         "installed temporary setup authentication key into slot {}",
         setup_auth_key_id
     );
 
-    let mut client = Client::open(
+    let connector = client.connector().clone();
+
+    // Create a new client, connecting with the temporary auth key
+    let client = Client::open(
         connector,
         Credentials::new(setup_auth_key_id, temp_auth_key),
-        ENABLE_RECONNECT_DURING_RESET,
+        false,
     )
     .map_err(|e| format_err!("error reconnecting to HSM with setup auth key: {}", e))?;
 
@@ -87,7 +84,7 @@ pub fn erase_device_and_init_with_profile(
             )
         })?;
 
-    let report = profile.provision(&mut client)?;
+    let report = profile.provision(&client)?;
 
     if profile.delete_setup_auth_key {
         warn!(
@@ -106,50 +103,4 @@ pub fn erase_device_and_init_with_profile(
     }
 
     Ok(report)
-}
-
-/// Perform the device reset
-fn perform_device_reset(
-    connector: Connector,
-    credentials: Credentials,
-    timeout: Duration,
-) -> Result<Client, Error> {
-    // Warn people and give them a brief grace period to avoid oblitering their HSM
-    warn!("factory resetting HSM device! all data will be lost!");
-    thread::sleep(Duration::from_millis(DEVICE_RESET_WAIT_MS));
-
-    // Reset the device
-    Client::open(connector.clone(), credentials, false)?.reset_device()?;
-
-    let deadline = SystemTime::now() + timeout;
-
-    info!("waiting for device reset to complete");
-    thread::sleep(Duration::from_millis(DEVICE_RESET_WAIT_MS));
-
-    // Attempt to reconnect to the device with the default credentials
-    loop {
-        match Client::open(
-            connector.clone(),
-            Credentials::default(),
-            ENABLE_RECONNECT_DURING_RESET,
-        ) {
-            Ok(client) => {
-                debug!("successfully reconnected to HSM after reset!");
-                return Ok(client);
-            }
-            Err(e) => {
-                // If we're past the deadline, return an error
-                if SystemTime::now() >= deadline {
-                    bail!(
-                        "timed out after {} seconds connecting to HSM after reset: {}",
-                        timeout.as_secs(),
-                        e
-                    )
-                } else {
-                    debug!("error reconnecting to HSM: {}", e);
-                    thread::sleep(Duration::from_millis(DEVICE_POLL_INTERVAL_MS))
-                }
-            }
-        }
-    }
 }

--- a/src/setup/profile.rs
+++ b/src/setup/profile.rs
@@ -97,7 +97,7 @@ impl Profile {
     }
 
     /// Use this profile to provision the YubiHSM 2 with the given client
-    pub fn provision(&self, client: &mut Client) -> Result<Report, Error> {
+    pub fn provision(&self, client: &Client) -> Result<Report, Error> {
         for role in &self.roles {
             info!("installing role: {}", role.authentication_key_label);
             role.create(client)?;

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -73,7 +73,7 @@ impl Report {
     }
 
     /// Store this report in the YubiHSM at the given object ID
-    pub fn store(&self, client: &mut Client, report_object_id: object::Id) -> Result<(), Error> {
+    pub fn store(&self, client: &Client, report_object_id: object::Id) -> Result<(), Error> {
         client
             .put_opaque(
                 report_object_id,

--- a/src/setup/role.rs
+++ b/src/setup/role.rs
@@ -64,7 +64,7 @@ impl Role {
     }
 
     /// Create this role within the YubiHSM 2 device
-    pub fn create(&self, client: &mut Client) -> Result<(), Error> {
+    pub fn create(&self, client: &Client) -> Result<(), Error> {
         client
             .put_authentication_key(
                 self.credentials.authentication_key_id,

--- a/src/wrap/key.rs
+++ b/src/wrap/key.rs
@@ -87,7 +87,7 @@ impl Key {
     }
 
     /// Create this key within the HSM
-    pub fn create(&self, client: &mut Client) -> Result<(), ClientError> {
+    pub fn create(&self, client: &Client) -> Result<(), ClientError> {
         let algorithm = self.import_params.algorithm.wrap().unwrap();
 
         client.put_wrap_key(


### PR DESCRIPTION
This refactors the setup process so as to support skipping an initial device reset.

It seems certain YubiHSM2s (possibly from a bad batch) have trouble completing the reset process. In cases like that, it would be nice to provide an option to not reset the device.

This also makes the `reset_device_and_reconnect` method a public method of `yubihsm::Client`, in case someone would like to reset and reconnect, but doesn't want to use our `yubihsm::setup` provisioning.