### PR TITLE
Remove byteorder crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ circle-ci = { repository = "tendermint/yubihsm-rs", branch = "develop" }
 aes = "0.3"
 bitflags = "1"
 block-modes = "0.3"
-byteorder = "1.2"
 chrono = { version = "0.4", features=["serde"], optional = true }
 cmac = "0.2"
 failure = "0.1"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
-![Rust 1.31+][rustc-image]
+![Rust 1.32+][rustc-image]
 [![Build Status][build-image]][build-link]
 
 Pure Rust client for [YubiHSM 2] devices from [Yubico].
@@ -31,7 +31,7 @@ or endorsed by Yubico (although whoever runs their Twitter account
 
 ## Prerequisites
 
-This crate builds on Rust 1.31+.
+This crate builds on Rust 1.32+.
 
 On x86(-64) targets, add the following `RUSTFLAGS` to enable AES-NI to better
 secure communication with the YubiHSM:
@@ -161,7 +161,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [docs-image]: https://docs.rs/yubihsm/badge.svg
 [docs-link]: https://docs.rs/yubihsm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.34+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.32+-blue.svg
 [build-image]: https://circleci.com/gh/tendermint/yubihsm-rs.svg?style=shield
 [build-link]: https://circleci.com/gh/tendermint/yubihsm-rs
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -42,7 +42,6 @@ use std::{thread, time::SystemTime};
 #[cfg(feature = "rsa-preview")]
 use {
     crate::rsa::{self, pkcs1::commands::*, pss::commands::*},
-    byteorder::{BigEndian, ByteOrder},
     sha2::{Digest, Sha256},
 };
 
@@ -925,9 +924,8 @@ impl Client {
 
         let mut hasher = Sha256::default();
 
-        let mut length = [0u8; 2];
-        BigEndian::write_u16(&mut length, data.len() as u16);
-        hasher.input(&length);
+        let length = data.len() as u16;
+        hasher.input(&length.to_be_bytes());
         hasher.input(data);
         let digest = hasher.result();
 

--- a/src/serialization/de.rs
+++ b/src/serialization/de.rs
@@ -1,12 +1,9 @@
 //! Serde-powered deserializer for `YubiHSM` messages
 
-use std::io::Read;
-
-use byteorder::{BigEndian, ReadBytesExt};
+use super::error::SerializationError;
 use serde;
 use serde::de::{DeserializeSeed, SeqAccess, Visitor};
-
-use super::error::SerializationError;
+use std::io::Read;
 
 /// Deserializer for `YubiHSM` messages, which reads from a reader object
 pub struct Deserializer<R: Read> {
@@ -42,7 +39,9 @@ impl<'de, 'a, R: Read> serde::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u8(self.reader.read_u8()?)
+        let mut byte = [0u8];
+        self.reader.read_exact(&mut byte)?;
+        visitor.visit_u8(byte[0])
     }
 
     #[inline]
@@ -50,8 +49,9 @@ impl<'de, 'a, R: Read> serde::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let value = self.reader.read_u16::<BigEndian>()?;
-        visitor.visit_u16(value)
+        let mut bytes = [0u8; 2];
+        self.reader.read_exact(&mut bytes)?;
+        visitor.visit_u16(u16::from_be_bytes(bytes))
     }
 
     #[inline]
@@ -59,8 +59,9 @@ impl<'de, 'a, R: Read> serde::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let value = self.reader.read_u32::<BigEndian>()?;
-        visitor.visit_u32(value)
+        let mut bytes = [0u8; 4];
+        self.reader.read_exact(&mut bytes)?;
+        visitor.visit_u32(u32::from_be_bytes(bytes))
     }
 
     #[inline]
@@ -68,8 +69,9 @@ impl<'de, 'a, R: Read> serde::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let value = self.reader.read_u64::<BigEndian>()?;
-        visitor.visit_u64(value)
+        let mut bytes = [0u8; 8];
+        self.reader.read_exact(&mut bytes)?;
+        visitor.visit_u64(u64::from_be_bytes(bytes))
     }
 
     #[inline]

--- a/src/serialization/ser.rs
+++ b/src/serialization/ser.rs
@@ -1,16 +1,12 @@
 //! Serde-powered serializer for `YubiHSM` messages
 
-use std::io::Write;
-use std::u32;
-
-use byteorder::{BigEndian, WriteBytesExt};
+use super::error::SerializationError;
 use serde;
 use serde::ser::{
     SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant,
 };
-
-use super::error::SerializationError;
+use std::{io::Write, u32};
 
 /// Serializer for `YubiHSM` messages
 pub(crate) struct Serializer<W> {
@@ -47,19 +43,19 @@ impl<'a, W: Write> serde::Serializer for &'a mut Serializer<W> {
     }
 
     fn serialize_u8(self, v: u8) -> Result<(), SerializationError> {
-        self.writer.write_u8(v).map_err(Into::into)
+        self.writer.write_all(&[v]).map_err(Into::into)
     }
 
     fn serialize_u16(self, v: u16) -> Result<(), SerializationError> {
-        self.writer.write_u16::<BigEndian>(v).map_err(Into::into)
+        self.writer.write_all(&v.to_be_bytes()).map_err(Into::into)
     }
 
     fn serialize_u32(self, v: u32) -> Result<(), SerializationError> {
-        self.writer.write_u32::<BigEndian>(v).map_err(Into::into)
+        self.writer.write_all(&v.to_be_bytes()).map_err(Into::into)
     }
 
     fn serialize_u64(self, v: u64) -> Result<(), SerializationError> {
-        self.writer.write_u64::<BigEndian>(v).map_err(Into::into)
+        self.writer.write_all(&v.to_be_bytes()).map_err(Into::into)
     }
 
     fn serialize_i8(self, _: i8) -> Result<(), SerializationError> {

--- a/src/session/message.rs
+++ b/src/session/message.rs
@@ -6,18 +6,14 @@
 //!
 //! <https://developers.yubico.com/YubiHSM2/Commands/>
 
-use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use uuid::Uuid;
-
 use super::{
     error::{SessionError, SessionErrorKind::ProtocolError},
     securechannel::{Mac, MAC_SIZE},
-    session::Id,
 };
-use command::command::Code;
+use crate::{command, response, session};
 #[cfg(feature = "mockhsm")]
-use error::DeviceErrorKind;
-use response::response::Code;
+use crate::error::DeviceErrorKind;
 
 /// Maximum size of a message sent to/from the YubiHSM
 pub const MAX_MSG_SIZE: usize = 2048;

--- a/src/session/securechannel/kdf.rs
+++ b/src/session/securechannel/kdf.rs
@@ -2,12 +2,9 @@
 //! counter mode KDF as described in NIST SP 800-108 (NIST 800-108)
 //! with "fixed input data" specific to the SCP03 protocol
 
-use aes::Aes128;
-use byteorder::{BigEndian, ByteOrder};
-use cmac::crypto_mac::Mac;
-use cmac::Cmac;
-
 use super::{Context, KEY_SIZE};
+use aes::Aes128;
+use cmac::{crypto_mac::Mac, Cmac};
 
 /// Derive a slice of output data using SCP03's KDF
 pub fn derive(mac_key: &[u8], derivation_constant: u8, context: &Context, output: &mut [u8]) {
@@ -30,7 +27,8 @@ pub fn derive(mac_key: &[u8], derivation_constant: u8, context: &Context, output
     derivation_data[12] = 0x00;
 
     // "L": length of derived data in bits
-    BigEndian::write_u16(&mut derivation_data[13..15], (output_len * 8) as u16);
+    let length = (output_len * 8) as u16;
+    derivation_data[13..15].copy_from_slice(&length.to_be_bytes());
 
     // "i": KDF counter for deriving more than one block-length of data
     // Hardcoded to 1 as we don't support deriving more than 128-bits


### PR DESCRIPTION
This commit switches to the byteorder conversions which are built into `core`/`std` as of Rust 1.32.