### PR TITLE
v0.23.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.23.0] (2019-05-20)
+
+- Remove `byteorder` crate ([#201])
+- 2018 edition idiom cleanups ([#200])
+- setup: Support for (optionally) skipping initial device reset ([#199])
+- Upgrade to `block-modes` v0.3 ([#198])
+- Upgrade to `zeroize` 0.8 ([#197]) 
+- Switch from `rand_os` to `getrandom` ([#195])
+
 ## [0.22.0] (2019-03-24)
 
 - Integrate Signatory types ([#192])
@@ -223,6 +232,13 @@ to adding support for several commands.
 
 - Initial release
 
+[0.23.0]: https://github.com/tendermint/yubihsm-rs/pull/202
+[#201]: https://github.com/tendermint/yubihsm-rs/pull/201
+[#200]: https://github.com/tendermint/yubihsm-rs/pull/200
+[#199]: https://github.com/tendermint/yubihsm-rs/pull/199
+[#198]: https://github.com/tendermint/yubihsm-rs/pull/198
+[#197]: https://github.com/tendermint/yubihsm-rs/pull/197
+[#195]: https://github.com/tendermint/yubihsm-rs/pull/195
 [0.22.0]: https://github.com/tendermint/yubihsm-rs/pull/194
 [#192]: https://github.com/tendermint/yubihsm-rs/pull/192
 [#191]: https://github.com/tendermint/yubihsm-rs/pull/191

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 USB-based access to the device. Supports most HSM functionality
                 including ECDSA, Ed25519, HMAC, and RSA.
                 """
-version       = "0.22.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.23.0" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.22.0"
+    html_root_url = "https://docs.rs/yubihsm/0.23.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Remove `byteorder` crate (#201)
- 2018 edition idiom cleanups (#200)
- setup: Support for (optionally) skipping initial device reset (#199)
- Upgrade to `block-modes` v0.3 (#198)
- Upgrade to `zeroize` 0.8 (#197) 
- Switch from `rand_os` to `getrandom` (#195)