### PR TITLE
Retry commands after session messages limits are exceeded

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -17,6 +17,7 @@ pub const MAX_MSG_SIZE: usize = 2048;
 /// the HSM. Every command has a corresponding `ResponseType`.
 ///
 /// See <https://developers.yubico.com/YubiHSM2/Commands>
+// TODO(tarcieri): add a `Zeroize` bound to clear sensitive data
 pub(crate) trait Command: Serialize + DeserializeOwned + Sized {
     /// Response type for this command
     type ResponseType: Response;
@@ -25,8 +26,8 @@ pub(crate) trait Command: Serialize + DeserializeOwned + Sized {
     const COMMAND_CODE: Code = Self::ResponseType::COMMAND_CODE;
 }
 
-impl<C: Command> From<C> for Message {
-    fn from(command: C) -> Message {
-        Self::create(C::COMMAND_CODE, serialize(&command).unwrap()).unwrap()
+impl<'c, C: Command> From<&'c C> for Message {
+    fn from(command: &C) -> Message {
+        Self::create(C::COMMAND_CODE, serialize(command).unwrap()).unwrap()
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -135,7 +135,7 @@ impl Session {
     /// Encrypt a command, send it to the HSM, then read and decrypt the response
     pub(crate) fn send_command<C: Command>(
         &mut self,
-        command: C,
+        command: &C,
     ) -> Result<C::ResponseType, SessionError> {
         let plaintext_cmd = command::Message::from(command);
         let cmd_type = plaintext_cmd.command_type;
@@ -278,7 +278,7 @@ impl Drop for Session {
         // TODO: ensure we're really unwind safe.
         // This should still be better than panicking in a drop handler, hopefully
         let result = panic::catch_unwind(AssertUnwindSafe(|| {
-            self.send_command(CloseSessionCommand {}).unwrap()
+            self.send_command(&CloseSessionCommand {}).unwrap()
         }));
 
         if let Err(err) = result {


### PR DESCRIPTION
The `SessionErrorKind::CommandLimitExceeded` error occurs when too many messages have been sent in a given session, exceeding the `MAX_COMMANDS_PER_SESSION` value (2^20).

When this limit is exceeded, an error is eagerly returned from `encrypt_command` indicating that the current session should be closed and a new one created with a fresh session key.

Previously these errors bubbled up and were returned from the client. This commit retries the command by initiating a new session and, if successful, resending the command.

This approach is still idempotent as the error `SessionErrorKind::CommandLimitExceeded` is eagerly returned before any messages are sent to the HSM, ensuring that the HSM will not
receive the same command twice in this instance.