### PR TITLE
Improve Client's 'reset_device_and_reconnect' API

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -22,9 +22,8 @@ pub fn erase_device_and_init_with_profile(
     profile: Profile,
 ) -> Result<Report, Error> {
     // Reset the device
-    let client = Client::open(connector.clone(), credentials, false)?
-        .reset_device_and_reconnect(profile.reset_device_timeout)?;
-
+    let mut client = Client::open(connector, credentials, false)?;
+    client.reset_device_and_reconnect(profile.reset_device_timeout)?;
     init_with_profile(client, profile)
 }
 


### PR DESCRIPTION
This change takes a mutable reference to the client, rather than returning a new client, and attempts to initiate a new session using the existing client.