### PR TITLE
v0.24.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.24.0] (2019-06-04)
+
+- Eliminate module name prefixes from error types ([#209])
+- Upgrade to zeroize 0.9 ([#208])
+- Improve `yubihsm::Client`'s `reset_device_and_reconnect` API ([#204])
+- Retry commands after session messages limits are exceeded ([#203])
+
 ## [0.23.0] (2019-05-20)
 
 - Remove `byteorder` crate ([#201])
@@ -232,6 +239,11 @@ to adding support for several commands.
 
 - Initial release
 
+[0.24.0]: https://github.com/tendermint/yubihsm-rs/pull/210
+[#209]: https://github.com/tendermint/yubihsm-rs/pull/209
+[#208]: https://github.com/tendermint/yubihsm-rs/pull/208
+[#204]: https://github.com/tendermint/yubihsm-rs/pull/204
+[#203]: https://github.com/tendermint/yubihsm-rs/pull/203
 [0.23.0]: https://github.com/tendermint/yubihsm-rs/pull/202
 [#201]: https://github.com/tendermint/yubihsm-rs/pull/201
 [#200]: https://github.com/tendermint/yubihsm-rs/pull/200

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 USB-based access to the device. Supports most HSM functionality
                 including ECDSA, Ed25519, HMAC, and RSA.
                 """
-version       = "0.23.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.24.0" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.23.0"
+    html_root_url = "https://docs.rs/yubihsm/0.24.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Eliminate module name prefixes from error types (#209)
- Upgrade to zeroize 0.9 (#208)
- Improve `yubihsm::Client`'s `reset_device_and_reconnect` API (#204)
- Retry commands after session messages limits are exceeded (#203)