### PR TITLE
Upgrade to `signatory` v0.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ version: 2
 jobs:
   build:
     docker:
-    - image: tendermint/kms:build-2019-01-24-v0 # bump cache keys when modifying this
+    - image: tendermint/kms:build-2019-06-05-v0 # bump cache keys when modifying this
 
     steps:
     - checkout
     - restore_cache:
-        key: cache-2018-11-27-v0 # bump save_cache key below too
+        key: cache-2019-06-05-v0 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -74,7 +74,7 @@ jobs:
           cargo audit --version
           cargo audit
     - save_cache:
-        key: cache-2018-11-27-v0 # bump restore_cache key above too
+        key: cache-2019-06-05-v0 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,11 @@ pbkdf2 = { version = "0.3", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
 ring = { version = "0.14", optional = true }
-secp256k1 = { version = "0.12", optional = true }
+secp256k1 = { version = "0.13", optional = true }
 sha2 = { version = "0.8", optional = true }
-signatory = { version = "0.11", features = ["digest", "ecdsa", "ed25519"] }
+signatory = { version = "0.12", features = ["digest", "ecdsa", "ed25519"] }
+signature = "0.2"
+signature_derive = "0.2"
 subtle = "2"
 untrusted = { version = "0.6", optional = true }
 uuid = { version = "0.7", default-features = false }
@@ -49,8 +51,8 @@ zeroize = "0.9"
 criterion = "0.2"
 lazy_static = "1"
 ring = "0.14"
-signatory-ring = "0.11"
-signatory-secp256k1 = "0.11"
+signatory-ring = "0.12"
+signatory-secp256k1 = "0.12"
 untrusted = "0.6"
 
 [features]

--- a/src/asymmetric/public_key.rs
+++ b/src/asymmetric/public_key.rs
@@ -82,7 +82,7 @@ impl PublicKey {
     /// Return the Ed25519 public key if applicable
     pub fn ed25519(&self) -> Option<ed25519::PublicKey> {
         if self.algorithm == asymmetric::Algorithm::Ed25519 {
-            ed25519::PublicKey::from_bytes(&self.bytes).ok()
+            ed25519::PublicKey::from_bytes(&self.bytes)
         } else {
             None
         }

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -97,9 +97,6 @@ impl From<serialization::Error> for Error {
 
 impl From<Error> for signatory::Error {
     fn from(client_error: Error) -> signatory::Error {
-        signatory::Error::new(
-            signatory::ErrorKind::ProviderError,
-            Some(&client_error.to_string()),
-        )
+        signatory::Error::from_cause(client_error)
     }
 }

--- a/src/ed25519/signer.rs
+++ b/src/ed25519/signer.rs
@@ -4,11 +4,7 @@
 //! call the appropriate signer methods to obtain signers.
 
 use crate::{object, Client};
-use signatory::{
-    ed25519,
-    error::{Error, ErrorKind::*},
-    PublicKeyed,
-};
+use signatory::{ed25519, Error, PublicKeyed};
 
 /// Ed25519 signature provider for yubihsm-client
 pub struct Signer {
@@ -37,20 +33,12 @@ impl Signer {
 impl PublicKeyed<ed25519::PublicKey> for Signer {
     fn public_key(&self) -> Result<ed25519::PublicKey, Error> {
         let public_key = self.client.get_public_key(self.signing_key_id)?;
-        public_key.ed25519().ok_or_else(|| {
-            Error::new(
-                KeyInvalid,
-                Some(&format!(
-                    "expected an ed25519 key, got: {:?}",
-                    public_key.algorithm
-                )),
-            )
-        })
+        public_key.ed25519().ok_or_else(Error::new)
     }
 }
 
 impl signatory::Signer<ed25519::Signature> for Signer {
-    fn sign(&self, msg: &[u8]) -> Result<ed25519::Signature, Error> {
+    fn try_sign(&self, msg: &[u8]) -> Result<ed25519::Signature, Error> {
         Ok(self.client.sign_ed25519(self.signing_key_id, msg)?)
     }
 }

--- a/tests/ecdsa/mod.rs
+++ b/tests/ecdsa/mod.rs
@@ -8,7 +8,7 @@ use signatory::{
         curve::{NistP256, NistP384, WeierstrassCurve, WeierstrassCurveKind},
         Asn1Signature,
     },
-    PublicKeyed,
+    PublicKeyed, Verifier,
 };
 #[cfg(all(feature = "secp256k1", not(feature = "mockhsm")))]
 use signatory_secp256k1::EcdsaVerifier as Secp256k1Verifier;
@@ -70,9 +70,9 @@ fn create_yubihsm_key(client: &Client, key_id: object::Id, alg: yubihsm::asymmet
 #[cfg(not(feature = "mockhsm"))]
 fn ecdsa_nistp256_sign_test() {
     let signer = create_signer::<NistP256>(201);
-    let signature: Asn1Signature<_> = signatory::sign_sha256(&signer, TEST_MESSAGE).unwrap();
-    let verifier = signatory_ring::ecdsa::P256Verifier::from(&signer.public_key().unwrap());
-    assert!(signatory::verify_sha256(&verifier, TEST_MESSAGE, &signature).is_ok());
+    let signature: Asn1Signature<_> = signer.sign(TEST_MESSAGE);
+    let verifier = signatory_ring::ecdsa::p256::Verifier::from(&signer.public_key().unwrap());
+    assert!(verifier.verify(TEST_MESSAGE, &signature).is_ok());
 }
 
 // Use *ring* to verify NIST P-384 ECDSA signatures
@@ -80,9 +80,9 @@ fn ecdsa_nistp256_sign_test() {
 #[test]
 fn ecdsa_nistp384_sign_test() {
     let signer = create_signer::<NistP384>(202);
-    let signature: Asn1Signature<_> = signatory::sign_sha384(&signer, TEST_MESSAGE).unwrap();
-    let verifier = signatory_ring::ecdsa::P384Verifier::from(&signer.public_key().unwrap());
-    assert!(signatory::verify_sha384(&verifier, TEST_MESSAGE, &signature).is_ok());
+    let signature: Asn1Signature<_> = signer.sign(TEST_MESSAGE);
+    let verifier = signatory_ring::ecdsa::p384::Verifier::from(&signer.public_key().unwrap());
+    assert!(verifier.verify(TEST_MESSAGE, &signature).is_ok());
 }
 
 // Use `secp256k1` crate to verify secp256k1 ECDSA signatures.
@@ -91,7 +91,7 @@ fn ecdsa_nistp384_sign_test() {
 #[test]
 fn ecdsa_secp256k1_sign_test() {
     let signer = create_signer::<Secp256k1>(203);
-    let signature: Asn1Signature<_> = signatory::sign_sha256(&signer, TEST_MESSAGE).unwrap();
+    let signature: Asn1Signature<_> = signer.sign(TEST_MESSAGE);
     let verifier = Secp256k1Verifier::from(&signer.public_key().unwrap());
-    assert!(signatory::verify_sha256(&verifier, TEST_MESSAGE, &signature).is_ok());
+    assert!(verifier.verify(TEST_MESSAGE, &signature).is_ok());
 }

--- a/tests/ed25519/mod.rs
+++ b/tests/ed25519/mod.rs
@@ -1,5 +1,5 @@
-use signatory::PublicKeyed;
-use signatory_ring::ed25519::Ed25519Verifier;
+use signatory::{PublicKeyed, Verifier};
+use signatory_ring::ed25519::Verifier as Ed25519Verifier;
 use yubihsm::{asymmetric::Signer as SignerTrait, ed25519, Client};
 
 /// Key ID to use for test key
@@ -43,8 +43,8 @@ fn ed25519_sign_test() {
     create_yubihsm_key(&client);
 
     let signer = ed25519::Signer::create(client.clone(), TEST_SIGNING_KEY_ID).unwrap();
-    let signature = signer.sign(TEST_MESSAGE).unwrap();
-    let verifier = Ed25519Verifier::from(&signer.public_key().unwrap());
+    let signature = signer.sign(TEST_MESSAGE);
 
-    assert!(signatory::verify(&verifier, TEST_MESSAGE, &signature).is_ok());
+    let verifier = Ed25519Verifier::from(&signer.public_key().unwrap());
+    assert!(verifier.verify(TEST_MESSAGE, &signature).is_ok());
 }


### PR DESCRIPTION
Uses the `DigestSigner` and `DigestVerifier` traits from the `signature` crate, along with the custom derive support for `Signer` / `Verifier` in the `signature_derive` crate.