### PR TITLE
http-server feature: mimic yubihsm-connector functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,12 @@ jobs:
           cargo --version
           cargo build --features=usb --release
     - run:
+        name: build --all-features --examples
+        command: |
+          rustc --version
+          cargo --version
+          cargo build --all-features --examples
+    - run:
         name: test
         command: |
           rustc --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ signatory = { version = "0.12", features = ["digest", "ecdsa", "ed25519"] }
 signature = "0.2"
 signature_derive = "0.2.1"
 subtle = "2"
+tiny_http = { version = "0.6", optional = true }
 untrusted = { version = "0.6", optional = true }
 uuid = { version = "0.7", default-features = false }
 zeroize = "0.9"
@@ -57,6 +58,7 @@ untrusted = "0.6"
 
 [features]
 default = ["http", "passwords", "setup"]
+http-server = ["tiny_http"]
 http = ["gaunt"]
 force-audit-test = [] # TODO(tarcieri): clear audit log when tests start. See notes on PR#185
 mockhsm = ["passwords", "ring", "untrusted"]
@@ -66,8 +68,12 @@ setup = ["chrono", "passwords", "serde_json", "uuid/serde"]
 usb = ["lazy_static", "libusb"]
 
 [package.metadata.docs.rs]
-features = ["mockhsm", "rsa-preview", "secp256k1", "setup", "usb"]
+all-features = true
 
 [[bench]]
 name = "ed25519"
 harness = false
+
+[[example]]
+name = "connector_http_server"
+required-features = ["http-server"]

--- a/examples/connector_http_server.rs
+++ b/examples/connector_http_server.rs
@@ -1,0 +1,30 @@
+//! `yubihsm-connector` compatible HTTP server example.
+//!
+//! This exposes an HTTP server which provides an API that is compatible with
+//! the `yubihsm-connector` executable which comes with the YubiHSM SDK.
+//!
+//! It allows utilities like `yubihsm-shell` or other things written with
+//! `libyubihsm` to function in tandem with a Rust application
+//! communicating directly with the YubiHSM2 over USB.
+
+fn main() {
+    println!("opening USB connection to yubihsm");
+    let connector = yubihsm::Connector::usb(&Default::default());
+
+    // http://127.0.0.1:12345
+    let http_config = yubihsm::connector::HttpConfig::default();
+
+    println!(
+        "starting server at http://{}:{}",
+        &http_config.addr, http_config.port
+    );
+
+    let server = yubihsm::connector::http::Server::new(&http_config, connector).unwrap();
+
+    println!("server started! connect by running:\n");
+    println!("    $ yubihsm-shell");
+    println!("    yubihsm> connect");
+    println!("    yubihsm> session open 1 <password>");
+
+    server.run().unwrap();
+}

--- a/src/command/message.rs
+++ b/src/command/message.rs
@@ -95,7 +95,7 @@ impl Message {
     }
 
     /// Parse a command structure from a vector, taking ownership of the vector
-    #[cfg(feature = "mockhsm")]
+    #[cfg(any(feature = "http-server", feature = "mockhsm"))]
     pub fn parse(mut bytes: Vec<u8>) -> Result<Self, session::Error> {
         if bytes.len() < 3 {
             fail!(

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -19,7 +19,7 @@ mod error;
 mod connectable;
 mod connection;
 #[cfg(feature = "http")]
-mod http;
+pub mod http;
 mod message;
 #[cfg(feature = "usb")]
 pub mod usb;

--- a/src/connector/http.rs
+++ b/src/connector/http.rs
@@ -4,8 +4,12 @@
 
 mod config;
 mod connection;
+#[cfg(feature = "http-server")]
+mod server;
 
 pub use self::config::HttpConfig;
+#[cfg(feature = "http-server")]
+pub use self::server::Server;
 
 use self::connection::HttpConnection;
 use crate::connector::{self, Connectable, Connection};

--- a/src/connector/http/server.rs
+++ b/src/connector/http/server.rs
@@ -1,0 +1,147 @@
+//! HTTP server which provides a `yubihsm-connector` compatible API.
+//!
+//! This is useful for when you'd like an application to talk to the YubiHSM2
+//! directly, but still make use of utilities like `yubihsm-shell`.
+//!
+//! It's primarily intended for when a Rust application accessing the YubiHSM2
+//! via USB would like to share access to it via HTTP.
+
+// TODO(tarcieri): HTTPS support (needs `openssl`, would prefer `rustls`).
+// The main use case is on localhost anyway so support is debatable
+
+use super::config::HttpConfig;
+use crate::{
+    connector::{
+        Connector, Error,
+        ErrorKind::{AddrInvalid, RequestError},
+        Message,
+    },
+    uuid,
+};
+use std::{io, process, time::Instant};
+use tiny_http as http;
+
+/// `yubihsm-connector` compatible HTTP server
+pub struct Server {
+    /// Address to bind to
+    addr: String,
+
+    /// Port to listen on
+    port: u16,
+
+    /// HTTP server
+    server: http::Server,
+
+    /// YubiHSM2 connector
+    connector: Connector,
+}
+
+impl Server {
+    /// Create a new HTTP service which provides access to the YubiHSM2
+    pub fn new(config: &HttpConfig, connector: Connector) -> Result<Server, Error> {
+        let server = http::Server::http(format!("{}:{}", &config.addr, config.port))
+            .map_err(|e| err!(AddrInvalid, "couldn't create HTTP server: {}", e))?;
+
+        Ok(Self {
+            addr: config.addr.clone(),
+            port: config.port,
+            server,
+            connector,
+        })
+    }
+
+    /// Run the server's main loop, processing incoming requests
+    pub fn run(&self) -> Result<(), Error> {
+        loop {
+            self.handle_request()?;
+        }
+    }
+
+    /// Handle an incoming HTTP request
+    pub fn handle_request(&self) -> Result<(), Error> {
+        let mut request = self.server.recv()?;
+
+        let response = match *request.method() {
+            http::Method::Get => match request.url() {
+                "/connector/status" => Some(self.status()?),
+                _ => None,
+            },
+            http::Method::Post => match request.url() {
+                "/connector/api" => Some(self.api(&mut request)?),
+                _ => None,
+            },
+            _ => None,
+        }
+        .unwrap_or_else(|| {
+            http::Response::new(
+                http::StatusCode::from(404),
+                vec![],
+                io::Cursor::new(vec![]),
+                None,
+                None,
+            )
+        });
+
+        request.respond(response)?;
+        Ok(())
+    }
+
+    /// `GET /connector/status` - status page
+    fn status(&self) -> Result<http::Response<io::Cursor<Vec<u8>>>, Error> {
+        info!(
+            "yubihsm::http-server[{}:{}]: GET /connector/status",
+            &self.addr, self.port
+        );
+
+        let status = [
+            ("status", "OK"),
+            ("serial", "*"),
+            ("version", env!("CARGO_PKG_VERSION")),
+            ("pid", &process::id().to_string()),
+            ("address", &self.addr),
+            ("port", &self.port.to_string()),
+        ];
+
+        let body = status
+            .iter()
+            .map(|(k, v)| [*k, *v].join("\n"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        Ok(http::Response::from_string(body))
+    }
+
+    /// `POST /connector/api` - send message to the YubiHSM 2
+    fn api(
+        &self,
+        request: &mut http::Request,
+    ) -> Result<http::Response<io::Cursor<Vec<u8>>>, Error> {
+        let mut body = Vec::new();
+        request.as_reader().read_to_end(&mut body)?;
+
+        let command_msg = Message::from(body);
+        let command = command_msg
+            .clone()
+            .parse()
+            .map_err(|e| err!(RequestError, "couldn't parse request message: {}", e))?;
+
+        let started_at = Instant::now();
+        let response_msg = self.connector.send_message(uuid::new_v4(), command_msg)?;
+
+        let session = command
+            .session_id
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "none".to_owned());
+
+        info!(
+            "yubihsm::http-server[{}:{}]: POST /connector/api - session:{} cmd:{:?} t:{}ms",
+            &self.addr,
+            self.port,
+            &session,
+            command.command_type,
+            started_at.elapsed().as_millis()
+        );
+
+        Ok(http::Response::from_data(response_msg.as_ref()))
+    }
+}

--- a/src/connector/message.rs
+++ b/src/connector/message.rs
@@ -4,6 +4,7 @@
 use crate::{command, session};
 
 /// Messages sent to/from the HSM
+#[derive(Clone, Debug)]
 pub struct Message(pub(crate) Vec<u8>);
 
 impl AsRef<[u8]> for Message {
@@ -26,7 +27,7 @@ impl From<Message> for Vec<u8> {
 
 impl Message {
     /// Parse a `command::Message` from this `connector::Message`
-    #[cfg(feature = "mockhsm")]
+    #[cfg(any(feature = "http-server", feature = "mockhsm"))]
     pub(crate) fn parse(self) -> Result<command::Message, session::Error> {
         command::Message::parse(self.0)
     }

--- a/src/session/id.rs
+++ b/src/session/id.rs
@@ -1,4 +1,7 @@
+//! Session IDs: the YubiHSM2 supports up to 16 concurrent sessions.
+
 use super::{Error, ErrorKind::ProtocolError};
+use std::fmt::{self, Display};
 
 /// Maximum session identifier
 pub const MAX_SESSION_ID: Id = Id(16);
@@ -30,5 +33,11 @@ impl Id {
     /// Obtain session ID as a u8
     pub fn to_u8(self) -> u8 {
         self.0
+    }
+}
+
+impl Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }


### PR DESCRIPTION
This adds an embedded HTTP server (based on the `tiny_http` crate, and feature gated under the `http-server` cargo feature) which provides functionality equivalent to Yubico's `yubihsm-connector`.

It allows for using tools like `yubihsm-shell` while a Rust process is the primary one responsible for communicating with the YubiHSM2.