### PR TITLE
Fix `http-server` import bug

### DIFF
--- a/src/connector/message.rs
+++ b/src/connector/message.rs
@@ -1,6 +1,6 @@
 //! Wrapper type around messages sent to/from the HSM
 
-#[cfg(feature = "mockhsm")]
+#[cfg(any(feature = "http-server", feature = "mockhsm"))]
 use crate::{command, session};
 
 /// Messages sent to/from the HSM


### PR DESCRIPTION
It previously only compiled if the MockHSM was also enabled.