### PR TITLE
Improve missing auth key errors

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -171,7 +171,7 @@ impl Session {
         if response.is_err() {
             if let Some(kind) = device::ErrorKind::from_response_message(&response) {
                 session_debug!(self, "uuid={} failed={:?} error={:?}", uuid, cmd_type, kind);
-                return Err(kind.into());
+                Err(kind)?;
             } else {
                 session_debug!(self, "uuid={} failed={:?} error=unknown", uuid, cmd_type);
                 fail!(ErrorKind::ResponseError, "{:?} failed: HSM error", cmd_type);


### PR DESCRIPTION
Properly decodes error codes for create session failures, and provides a more helpful error message in the event auth is attempted against a nonexistent auth key.