### PR TITLE
v0.27.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.27.0] (2019-08-11)
+
+- Refactor `Algorithm` names to be camel case and subdivide RSA ([#228])
+- ecdh: Initial support for Derive ECDH command ([#227])
+- ssh: Initial support for the Sign SSH Certificate command ([#226])
+- template: Add support for get/put commands ([#225])
+- Rename `rsa-preview` cargo feature to `yolocrypto` ([#224])
+- Upgrade to signatory v0.13 ([#223])
+
 ## [0.26.4] (2019-06-24)
 
 - Improve missing auth key errors ([#221])
@@ -263,6 +272,13 @@ to adding support for several commands.
 
 - Initial release
 
+[0.27.0]: https://github.com/tendermint/yubihsm-rs/pull/229
+[#228]: https://github.com/tendermint/yubihsm-rs/pull/228
+[#227]: https://github.com/tendermint/yubihsm-rs/pull/227
+[#226]: https://github.com/tendermint/yubihsm-rs/pull/226
+[#225]: https://github.com/tendermint/yubihsm-rs/pull/225
+[#224]: https://github.com/tendermint/yubihsm-rs/pull/224
+[#223]: https://github.com/tendermint/yubihsm-rs/pull/223
 [0.26.4]: https://github.com/tendermint/yubihsm-rs/pull/222
 [#221]: https://github.com/tendermint/yubihsm-rs/pull/221
 [0.26.3]: https://github.com/tendermint/yubihsm-rs/pull/220

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 USB-based access to the device. Supports most HSM functionality
                 including ECDSA, Ed25519, HMAC, and RSA.
                 """
-version       = "0.26.4" # Also update html_root_url in lib.rs when bumping this
+version       = "0.27.0" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,18 +51,11 @@
 //! [commands]: https://developers.yubico.com/YubiHSM2/Commands/
 //! [yubihsm-connector]: https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/
 
-#![deny(
-    warnings,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.26.4"
+    html_root_url = "https://docs.rs/yubihsm/0.27.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Refactor `Algorithm` names to be camel case and subdivide RSA (#228)
- ecdh: Initial support for Derive ECDH command (#227)
- ssh: Initial support for the Sign SSH Certificate command (#226)
- template: Add support for get/put commands (#225)
- Rename `rsa-preview` cargo feature to `yolocrypto` (#224)
- Upgrade to `signatory` v0.13 (#223)