### PR TITLE
connector: Switch from `libusb` to `rusb` (closes #230)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,11 @@ jobs:
           rustc --version
           cargo --version
           cargo test --features=mockhsm,secp256k1,yolocrypto
-    # TODO(tarcieri): re-enable when libusb is replaced
-    #- run:
-    #    name: audit
-    #    command: |
-    #      cargo audit --version
-    #      cargo audit
+    - run:
+        name: audit
+        command: |
+          cargo audit --version
+          cargo audit
     - save_cache:
         key: cache-2019-06-05-v0 # bump restore_cache key above too
         paths:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,12 @@ failure_derive = "0.1"
 gaunt = { version = "0.1", optional = true }
 getrandom = "0.1"
 hmac = { version = "0.7", optional = true }
-lazy_static = { version = "1", optional = true }
-libusb = { version = "0.3", optional = true }
 log = "0.4"
 pbkdf2 = { version = "0.3", optional = true, default-features = false }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = { version = "1", optional = true }
 ring = { version = "0.16", optional = true, default-features = false }
+rusb = { version = "0.5", optional = true }
 secp256k1 = { version = "0.15", optional = true }
 sha2 = { version = "0.8", optional = true }
 signatory = { version = "0.15", features = ["digest", "ecdsa", "ed25519"] }
@@ -60,7 +59,7 @@ http = ["gaunt"]
 mockhsm = ["passwords", "ring"]
 passwords = ["hmac", "pbkdf2", "sha2"]
 setup = ["chrono", "passwords", "serde_json", "uuid/serde"]
-usb = ["lazy_static", "libusb"]
+usb = ["rusb"]
 yolocrypto = ["sha2"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It provides two backends for communicating with YubiHSMs:
 - [HTTP][http-connector]: communicate with YubiHSM via the `yubihsm-connector`
   process from the Yubico SDK.
 - [USB][usb-connector]: communicate directly with the YubiHSM over USB using
-  the [libusb] crate.
+  the [rusb] crate.
 
 The [yubihsm::Client] type provides access to [HSM commands][command].
 
@@ -184,7 +184,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [usb-connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.usb
 [yubihsm::Client]: https://docs.rs/yubihsm/latest/yubihsm/client/struct.Client.html
 [command]: https://developers.yubico.com/YubiHSM2/Commands/
-[libusb]: https://github.com/dcuddeback/libusb-rs
+[rusb]: https://github.com/a1ien/rusb
 [thinks it's awesome]: https://twitter.com/Yubico/status/971186516796915712
 [YubiHSM2 commands]: https://developers.yubico.com/YubiHSM2/Commands/
 [Serde-based message parser]: https://github.com/tendermint/yubihsm-rs/tree/develop/src/serialization

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -3,7 +3,7 @@
 //! - [HTTP][http-connector]: communicate with YubiHSM via the `yubihsm-connector`
 //!   process from the Yubico SDK.
 //! - [USB][usb-connector]: communicate directly with the YubiHSM over USB using
-//!   the [libusb] crate.
+//!   the [rusb] crate.
 //!
 //! Additionally, this crate includes an optional development-only [mockhsm]
 //! (gated under a `mockhsm` cargo feature) which can be used as a drop-in
@@ -11,6 +11,7 @@
 //!
 //! [http-connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.http
 //! [usb-connector]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.usb
+//! [rusb]: https://github.com/a1ien/rusb
 //! [mockhsm]: https://docs.rs/yubihsm/latest/yubihsm/connector/struct.Connector.html#method.mockhsm
 
 #[macro_use]

--- a/src/connector/error.rs
+++ b/src/connector/error.rs
@@ -3,8 +3,6 @@
 use failure::Fail;
 #[cfg(feature = "http")]
 use gaunt;
-#[cfg(feature = "usb")]
-use libusb;
 use std::{fmt, io, num::ParseIntError, str::Utf8Error};
 
 /// `yubihsm-connector` related errors
@@ -76,12 +74,12 @@ impl From<gaunt::Error> for Error {
 }
 
 #[cfg(feature = "usb")]
-impl From<libusb::Error> for Error {
-    fn from(err: libusb::Error) -> Error {
+impl From<rusb::Error> for Error {
+    fn from(err: rusb::Error) -> Error {
         match err {
-            libusb::Error::Access => err!(ErrorKind::AccessDenied, "{}", err),
-            libusb::Error::Io => err!(ErrorKind::IoError, "{}", err),
-            libusb::Error::Pipe => err!(ErrorKind::UsbError, "lost connection to USB device"),
+            rusb::Error::Access => err!(ErrorKind::AccessDenied, "{}", err),
+            rusb::Error::Io => err!(ErrorKind::IoError, "{}", err),
+            rusb::Error::Pipe => err!(ErrorKind::UsbError, "lost connection to USB device"),
             _ => err!(ErrorKind::UsbError, "{}", err),
         }
     }

--- a/src/connector/usb.rs
+++ b/src/connector/usb.rs
@@ -36,9 +36,8 @@ pub const YUBIHSM2_BULK_IN_ENDPOINT: u8 = 0x81;
 /// Connect to the HSM via USB.
 ///
 /// `UsbConnector` is available when the `usb` cargo feature is enabled.
-/// It requires `libusb` as a dependency, but does not otherwise need the
-/// [Yubico SDK] (which is a vicarious dependency of `UsbConnector` which
-/// needs the `yubihsm-connector` process).
+/// It requires `rusb` as a dependency, but does not otherwise need the
+/// [Yubico SDK].
 ///
 /// [Yubico SDK]: https://developers.yubico.com/YubiHSM2/Releases/
 #[derive(Clone, Default, Debug)]


### PR DESCRIPTION
The `libusb` crate is unmaintained:

https://rustsec.org/advisories/RUSTSEC-2016-0004.html