### PR TITLE
Lint for 2018 edition idioms, allow warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
-![Rust 1.32+][rustc-image]
+![MSRV][rustc-image]
 [![Build Status][build-image]][build-link]
 
 Pure Rust client for [YubiHSM 2] devices from [Yubico].
@@ -31,7 +31,7 @@ or endorsed by Yubico (although whoever runs their Twitter account
 
 ## Prerequisites
 
-This crate builds on Rust 1.32+.
+This crate builds on Rust 1.36+.
 
 On x86(-64) targets, add the following `RUSTFLAGS` to enable AES-NI to better
 secure communication with the YubiHSM:
@@ -170,7 +170,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [docs-image]: https://docs.rs/yubihsm/badge.svg
 [docs-link]: https://docs.rs/yubihsm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.32+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [build-image]: https://circleci.com/gh/tendermint/yubihsm-rs.svg?style=shield
 [build-link]: https://circleci.com/gh/tendermint/yubihsm-rs
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -113,7 +113,7 @@ impl Client {
 
     /// Get current `Session` (either opening a new one or returning an already
     /// open one).
-    pub fn session(&self) -> Result<session::Guard, Error> {
+    pub fn session(&self) -> Result<session::Guard<'_>, Error> {
         // TODO(tarcieri): handle PoisonError better?
         let mut session_mutex_guard = self.session.lock().unwrap();
 
@@ -171,7 +171,7 @@ impl Client {
                 if e.kind() == session::ErrorKind::CommandLimitExceeded {
                     Ok(self.session()?.send_command(&command)?)
                 } else {
-                    Err(e)?
+                    Err(e.into())
                 }
             }
         }

--- a/src/connector/usb/connection.rs
+++ b/src/connector/usb/connection.rs
@@ -113,7 +113,7 @@ fn recv_message(
                 );
             }
             // All other errors we return immediately
-            Err(err) => Err(err)?,
+            Err(err) => return Err(err.into()),
         }
     }
 

--- a/src/connector/usb/device.rs
+++ b/src/connector/usb/device.rs
@@ -153,7 +153,7 @@ impl Devices {
     }
 
     /// Iterate over the detected YubiHSM 2s
-    pub fn iter(&self) -> Iter<Device> {
+    pub fn iter(&self) -> Iter<'_, Device> {
         self.0.iter()
     }
 }
@@ -234,7 +234,7 @@ impl Device {
 }
 
 impl Debug for Device {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "yubihsm::connector::usb::Device(bus={} addr={} serial=#{})",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,8 @@
 //! [commands]: https://developers.yubico.com/YubiHSM2/Commands/
 //! [yubihsm-connector]: https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector/
 
-#![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/develop/img/logo.png",
     html_root_url = "https://docs.rs/yubihsm/0.27.0"

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -264,7 +264,7 @@ impl Objects {
     }
 
     /// Iterate over the objects
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         self.0.iter()
     }
 }

--- a/src/mockhsm/session.rs
+++ b/src/mockhsm/session.rs
@@ -54,7 +54,7 @@ impl HsmSession {
 }
 
 impl Debug for HsmSession {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "mockhsm::Session {{ id: {} }}", self.id.to_u8())
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -171,7 +171,7 @@ impl Session {
         if response.is_err() {
             if let Some(kind) = device::ErrorKind::from_response_message(&response) {
                 session_debug!(self, "uuid={} failed={:?} error={:?}", uuid, cmd_type, kind);
-                Err(kind)?;
+                return Err(kind.into());
             } else {
                 session_debug!(self, "uuid={} failed={:?} error=unknown", uuid, cmd_type);
                 fail!(ErrorKind::ResponseError, "{:?} failed: HSM error", cmd_type);

--- a/src/session/id.rs
+++ b/src/session/id.rs
@@ -37,7 +37,7 @@ impl Id {
 }
 
 impl Display for Id {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -123,7 +123,7 @@ impl SecureChannel {
                     "auth key not found: 0x{:04x}",
                     credentials.authentication_key_id
                 ),
-                Some(kind) => Err(kind)?,
+                Some(kind) => return Err(kind.into()),
                 None => fail!(
                     ErrorKind::ResponseError,
                     "HSM error: {:?}",


### PR DESCRIPTION
Warnings are caught in CI with: `-D warnings`