### PR TITLE
Remove failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ bitflags = "1"
 block-modes = "0.3"
 chrono = { version = "0.4", features=["serde"], optional = true }
 cmac = "0.2"
-failure = "0.1"
-failure_derive = "0.1"
 gaunt = { version = "0.1", optional = true }
 getrandom = "0.1"
 hmac = { version = "0.7", optional = true }

--- a/src/audit/error.rs
+++ b/src/audit/error.rs
@@ -1,18 +1,22 @@
 use std::fmt;
 
-/// `Algorithm`-related errors
+/// Audit-related errors
 pub type Error = crate::Error<ErrorKind>;
 
-/// Kinds of `Algorithm`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Kinds of audit-related errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// Invalid algorithm tag
+    /// Invalid option
+    OptionInvalid,
+
+    /// Invalid tag
     TagInvalid,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
+            ErrorKind::OptionInvalid => "invalid option",
             ErrorKind::TagInvalid => "invalid tag",
         })
     }

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -4,6 +4,12 @@
 mod algorithm;
 pub mod commands;
 mod credentials;
+mod error;
 pub mod key;
 
-pub use self::{algorithm::Algorithm, credentials::*, key::Key};
+pub use self::{
+    algorithm::Algorithm,
+    credentials::*,
+    error::{Error, ErrorKind},
+    key::Key,
+};

--- a/src/authentication/error.rs
+++ b/src/authentication/error.rs
@@ -1,19 +1,19 @@
 use std::fmt;
 
-/// `Algorithm`-related errors
+/// Authentication errors
 pub type Error = crate::Error<ErrorKind>;
 
-/// Kinds of `Algorithm`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Kinds of authentication errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// Invalid algorithm tag
-    TagInvalid,
+    /// Key size is invalid
+    KeySizeInvalid,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            ErrorKind::TagInvalid => "invalid tag",
+            ErrorKind::KeySizeInvalid => "invalid key size",
         })
     }
 }

--- a/src/authentication/key.rs
+++ b/src/authentication/key.rs
@@ -1,6 +1,6 @@
 //! `YubiHSM 2` authentication keys (2 * AES-128 symmetric PSK) from which session keys are derived
 
-use failure::Fail;
+use super::{Error, ErrorKind};
 use getrandom::getrandom;
 #[cfg(feature = "hmac")]
 use hmac::Hmac;
@@ -55,7 +55,7 @@ impl Key {
     pub fn from_slice(key_slice: &[u8]) -> Result<Self, Error> {
         ensure!(
             key_slice.len() == SIZE,
-            ErrorKind::SizeInvalid,
+            ErrorKind::KeySizeInvalid,
             "expected {}-byte key, got {}",
             SIZE,
             key_slice.len()
@@ -116,14 +116,3 @@ impl From<[u8; SIZE]> for Key {
 }
 
 impl_array_serializers!(Key, SIZE);
-
-/// `authentication::Key`-related errors
-pub type Error = crate::Error<ErrorKind>;
-
-/// Kinds of `authentication::Key`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
-pub enum ErrorKind {
-    /// Size is invalid
-    #[fail(display = "invalid size")]
-    SizeInvalid,
-}

--- a/src/client.rs
+++ b/src/client.rs
@@ -127,7 +127,7 @@ impl Client {
         let session = Session::open(
             self.connector.clone(),
             self.credentials.as_ref().ok_or_else(|| {
-                err!(
+                format_err!(
                     ErrorKind::AuthenticationError,
                     "session reconnection disabled"
                 )
@@ -406,7 +406,7 @@ impl Client {
             response.0.len()
         );
 
-        AuditOption::from_u8(response.0[0]).map_err(|e| err!(ErrorKind::ProtocolError, e))
+        AuditOption::from_u8(response.0[0]).map_err(|e| format_err!(ErrorKind::ProtocolError, e))
     }
 
     /// Get some number of bytes of pseudo random data generated on the device.
@@ -1081,7 +1081,10 @@ impl Client {
         if result.0 == 1 {
             Ok(())
         } else {
-            Err(err!(ErrorKind::ResponseError, "HMAC verification failure"))
+            Err(format_err!(
+                ErrorKind::ResponseError,
+                "HMAC verification failure"
+            ))
         }
     }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,9 +2,13 @@
 //! by the HSM device, implemented in relevant modules.
 
 mod code;
+mod error;
 mod message;
 
-pub use self::code::Code;
+pub use self::{
+    code::Code,
+    error::{Error, ErrorKind},
+};
 
 pub(crate) use self::message::Message;
 use crate::{response::Response, serialization::serialize};

--- a/src/command/error.rs
+++ b/src/command/error.rs
@@ -1,19 +1,19 @@
 use std::fmt;
 
-/// `Algorithm`-related errors
+/// Command-related errors
 pub type Error = crate::Error<ErrorKind>;
 
-/// Kinds of `Algorithm`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Kinds of command-related errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// Invalid algorithm tag
-    TagInvalid,
+    /// Invalid code
+    CodeInvalid,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            ErrorKind::TagInvalid => "invalid tag",
+            ErrorKind::CodeInvalid => "invalid code",
         })
     }
 }

--- a/src/command/message.rs
+++ b/src/command/message.rs
@@ -106,7 +106,7 @@ impl Message {
         }
 
         let command_type =
-            command::Code::from_u8(bytes[0]).map_err(|e| err!(ProtocolError, "{}", e))?;
+            command::Code::from_u8(bytes[0]).map_err(|e| format_err!(ProtocolError, "{}", e))?;
 
         let mut length_bytes = [0u8; 2];
         length_bytes.copy_from_slice(&bytes[1..3]);

--- a/src/connector/error.rs
+++ b/src/connector/error.rs
@@ -1,59 +1,64 @@
 //! Error types for `yubihsm-connector`
 
-use failure::Fail;
-#[cfg(feature = "http")]
-use gaunt;
 use std::{fmt, io, num::ParseIntError, str::Utf8Error};
 
 /// `yubihsm-connector` related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// `yubihsm-connector` related error kinds
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
     /// Address provided was not valid
-    #[fail(display = "invalid address")]
     AddrInvalid,
 
     /// Access denied
-    #[fail(display = "access denied")]
     AccessDenied,
 
     /// YubiHSM 2 is busy (in use by another client / process)
-    #[fail(display = "device already in use")]
     DeviceBusyError,
 
     /// Couldn't connect to the YubiHSM 2
-    #[fail(display = "connection failed")]
     ConnectionFailed,
 
     /// Input/output error
-    #[fail(display = "I/O error")]
     IoError,
 
     /// Error making request
-    #[fail(display = "invalid request")]
     RequestError,
 
     /// `yubihsm-connector` sent bad response
-    #[fail(display = "bad connector response")]
     ResponseError,
 
     /// USB operation failed
     #[cfg(feature = "usb")]
-    #[fail(display = "USB error")]
     UsbError,
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ErrorKind::AddrInvalid => "invalid address",
+            ErrorKind::AccessDenied => "access denied",
+            ErrorKind::DeviceBusyError => "device already in use",
+            ErrorKind::ConnectionFailed => "connection failed",
+            ErrorKind::IoError => "I/O error",
+            ErrorKind::RequestError => "invalid request",
+            ErrorKind::ResponseError => "bad connector response",
+            #[cfg(feature = "usb")]
+            ErrorKind::UsbError => "USB error",
+        })
+    }
 }
 
 impl From<fmt::Error> for Error {
     fn from(err: fmt::Error) -> Self {
-        err!(ErrorKind::IoError, err.to_string())
+        format_err!(ErrorKind::IoError, err.to_string())
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        err!(ErrorKind::IoError, err.to_string())
+        format_err!(ErrorKind::IoError, err.to_string())
     }
 }
 
@@ -69,7 +74,7 @@ impl From<gaunt::Error> for Error {
             gaunt::ErrorKind::RequestError => ErrorKind::RequestError,
         };
 
-        err!(kind, err)
+        format_err!(kind, err)
     }
 }
 
@@ -77,22 +82,22 @@ impl From<gaunt::Error> for Error {
 impl From<rusb::Error> for Error {
     fn from(err: rusb::Error) -> Error {
         match err {
-            rusb::Error::Access => err!(ErrorKind::AccessDenied, "{}", err),
-            rusb::Error::Io => err!(ErrorKind::IoError, "{}", err),
-            rusb::Error::Pipe => err!(ErrorKind::UsbError, "lost connection to USB device"),
-            _ => err!(ErrorKind::UsbError, "{}", err),
+            rusb::Error::Access => format_err!(ErrorKind::AccessDenied, "{}", err),
+            rusb::Error::Io => format_err!(ErrorKind::IoError, "{}", err),
+            rusb::Error::Pipe => format_err!(ErrorKind::UsbError, "lost connection to USB device"),
+            _ => format_err!(ErrorKind::UsbError, "{}", err),
         }
     }
 }
 
 impl From<ParseIntError> for Error {
     fn from(err: ParseIntError) -> Self {
-        err!(ErrorKind::ResponseError, err.to_string())
+        format_err!(ErrorKind::ResponseError, err.to_string())
     }
 }
 
 impl From<Utf8Error> for Error {
     fn from(err: Utf8Error) -> Self {
-        err!(ErrorKind::ResponseError, err.to_string())
+        format_err!(ErrorKind::ResponseError, err.to_string())
     }
 }

--- a/src/connector/http/server.rs
+++ b/src/connector/http/server.rs
@@ -40,7 +40,7 @@ impl Server {
     /// Create a new HTTP service which provides access to the YubiHSM2
     pub fn new(config: &HttpConfig, connector: Connector) -> Result<Server, Error> {
         let server = http::Server::http(format!("{}:{}", &config.addr, config.port))
-            .map_err(|e| err!(AddrInvalid, "couldn't create HTTP server: {}", e))?;
+            .map_err(|e| format_err!(AddrInvalid, "couldn't create HTTP server: {}", e))?;
 
         info!(
             "yubihsm::http-server[{}:{}]: listening for connections",
@@ -128,7 +128,7 @@ impl Server {
         let command = command_msg
             .clone()
             .parse()
-            .map_err(|e| err!(RequestError, "couldn't parse request message: {}", e))?;
+            .map_err(|e| format_err!(RequestError, "couldn't parse request message: {}", e))?;
 
         let started_at = Instant::now();
         let response_msg = self.connector.send_message(uuid::new_v4(), command_msg)?;

--- a/src/connector/usb/device.rs
+++ b/src/connector/usb/device.rs
@@ -91,7 +91,7 @@ impl Devices {
                 .map_err(|e| usb_err!(device, "error opening device: {}", e))?;
 
             handle.reset().map_err(|error| match error {
-                rusb::Error::NoDevice => err!(
+                rusb::Error::NoDevice => format_err!(
                     DeviceBusyError,
                     "USB(bus={},addr={}): couldn't reset device (already in use or disconnected)",
                     device.bus_number(),
@@ -117,7 +117,7 @@ impl Devices {
             let serial_number: SerialNumber = handle
                 .read_serial_number_string(language, &desc, t)?
                 .parse()
-                .map_err(|e| err!(AddrInvalid, "{}", e))?;
+                .map_err(|e| format_err!(AddrInvalid, "{}", e))?;
 
             debug!(
                 "USB(bus={},addr={}): found {} (serial #{})",

--- a/src/connector/usb/macros.rs
+++ b/src/connector/usb/macros.rs
@@ -22,7 +22,7 @@ macro_rules! usb_debug {
 /// Create `UsbError`s that include bus and address information
 macro_rules! usb_err {
     ($device:expr, $msg:expr) => {
-        err!(
+        format_err!(
             UsbError,
             "USB(bus={},addr={}): {}",
             $device.bus_number(),
@@ -31,7 +31,7 @@ macro_rules! usb_err {
         );
     };
     ($device:expr, $fmt:expr, $($arg:tt)+) => {
-        err!(
+        format_err!(
             UsbError,
             concat!("USB(bus={},addr={}): ", $fmt),
             $device.bus_number(),

--- a/src/device/error.rs
+++ b/src/device/error.rs
@@ -1,91 +1,72 @@
 //! Error types which map directly to the YubiHSM2's error codes
 
 use crate::response;
-use failure::Fail;
+use std::fmt;
 
 /// Errors which originate in the HSM
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of errors which originate in the HSM
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ErrorKind {
     /// Unknown HSM error codes
-    #[fail(display = "unknown HSM error code: 0x{:02x}", code)]
     Unknown {
         /// Unknown error code
         code: u8,
     },
 
     /// Invalid command
-    #[fail(display = "invalid command")]
     InvalidCommand,
 
     /// Invalid data
-    #[fail(display = "invalid data")]
     InvalidData,
 
     /// Invalid session
-    #[fail(display = "invalid session")]
     InvalidSession,
 
     /// Authentication failure
-    #[fail(display = "authentication failed")]
     AuthenticationFailed,
 
     /// Sessions full (HSM has a max of 16)
-    #[fail(display = "sessions full (max 16)")]
     SessionsFull,
 
     /// Session failed
-    #[fail(display = "session failed")]
     SessionFailed,
 
     /// Storage failed
-    #[fail(display = "storage failed")]
     StorageFailed,
 
     /// Wrong length
-    #[fail(display = "incorrect length")]
     WrongLength,
 
     /// Insufficient permissions
-    #[fail(display = "invalid permissions")]
     InsufficientPermissions,
 
     /// Audit log full
-    #[fail(display = "audit log full")]
     LogFull,
 
     /// Object not found
-    #[fail(display = "object not found")]
     ObjectNotFound,
 
     /// Invalid ID
-    #[fail(display = "invalid ID")]
     InvalidId,
 
     /// Invalid OTP
-    #[fail(display = "invalid OTP")]
     InvalidOtp,
 
     /// Demo mode(?)
-    #[fail(display = "demo mode")]
     DemoMode,
 
     /// Command unexecuted
-    #[fail(display = "command unexecuted")]
     CommandUnexecuted,
 
     /// Generic error
-    #[fail(display = "generic error")]
     GenericError,
 
     /// Object already exists
-    #[fail(display = "object already exists")]
     ObjectExists,
 
     /// SSH CA constraint violation
-    #[fail(display = "SSH CA constraint violation")]
     SshCaConstraintViolation,
 }
 
@@ -174,6 +155,32 @@ impl ErrorKind {
             Some(ErrorKind::from_u8(response.data[0]))
         } else {
             None
+        }
+    }
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorKind::Unknown { code } => write!(f, "unknown HSM error code: 0x{:02x}", code),
+            ErrorKind::InvalidCommand => f.write_str("invalid command"),
+            ErrorKind::InvalidData => f.write_str("invalid data"),
+            ErrorKind::InvalidSession => f.write_str("invalid session"),
+            ErrorKind::AuthenticationFailed => f.write_str("authentication failed"),
+            ErrorKind::SessionsFull => f.write_str("sessions full (max 16)"),
+            ErrorKind::SessionFailed => f.write_str("session failed"),
+            ErrorKind::StorageFailed => f.write_str("storage failed"),
+            ErrorKind::WrongLength => f.write_str("incorrect length"),
+            ErrorKind::InsufficientPermissions => f.write_str("invalid permissions"),
+            ErrorKind::LogFull => f.write_str("audit log full"),
+            ErrorKind::ObjectNotFound => f.write_str("object not found"),
+            ErrorKind::InvalidId => f.write_str("invalid ID"),
+            ErrorKind::InvalidOtp => f.write_str("invalid OTP"),
+            ErrorKind::DemoMode => f.write_str("demo mode"),
+            ErrorKind::CommandUnexecuted => f.write_str("command unexecuted"),
+            ErrorKind::GenericError => f.write_str("generic error"),
+            ErrorKind::ObjectExists => f.write_str("object already exists"),
+            ErrorKind::SshCaConstraintViolation => f.write_str("SSH CA constraint violation"),
         }
     }
 }

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -1,19 +1,19 @@
 use std::fmt;
 
-/// `Algorithm`-related errors
+/// Audit-related errors
 pub type Error = crate::Error<ErrorKind>;
 
-/// Kinds of `Algorithm`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Kinds of audit-related errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// Invalid algorithm tag
-    TagInvalid,
+    /// Invalid domain
+    DomainInvalid,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            ErrorKind::TagInvalid => "invalid tag",
+            ErrorKind::DomainInvalid => "invalid domain",
         })
     }
 }

--- a/src/ed25519/commands.rs
+++ b/src/ed25519/commands.rs
@@ -36,6 +36,6 @@ impl Response for SignEddsaResponse {
 
 impl SignEddsaResponse {
     pub(crate) fn signature(&self) -> Result<Signature, client::Error> {
-        Signature::from_bytes(&self.0).map_err(|e| err!(ResponseError, e))
+        Signature::from_bytes(&self.0).map_err(|e| format_err!(ResponseError, e))
     }
 }

--- a/src/mockhsm.rs
+++ b/src/mockhsm.rs
@@ -9,12 +9,16 @@ use std::sync::{Arc, Mutex};
 mod audit;
 mod command;
 mod connection;
+mod error;
 mod object;
 mod session;
 mod state;
 
-pub use self::connection::MockConnection;
 use self::state::State;
+pub use self::{
+    connection::MockConnection,
+    error::{Error, ErrorKind},
+};
 use crate::connector::{self, Connectable, Connection};
 
 /// Mock serial number for the MockHsm

--- a/src/mockhsm/connection.rs
+++ b/src/mockhsm/connection.rs
@@ -22,12 +22,12 @@ impl Connection for MockConnection {
     fn send_message(&self, _uuid: Uuid, message: Message) -> Result<Message, connector::Error> {
         let command = message
             .parse()
-            .map_err(|e| err!(ConnectionFailed, "error parsing command: {}", e))?;
+            .map_err(|e| format_err!(ConnectionFailed, "error parsing command: {}", e))?;
 
         let mut state = self
             .0
             .lock()
-            .map_err(|e| err!(ConnectionFailed, "error obtaining state lock: {}", e))?;
+            .map_err(|e| format_err!(ConnectionFailed, "error obtaining state lock: {}", e))?;
 
         match command.command_type {
             Code::CreateSession => command::create_session(&mut state, &command),

--- a/src/mockhsm/error.rs
+++ b/src/mockhsm/error.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+
+/// `MockHsm`-related errors
+pub type Error = crate::Error<ErrorKind>;
+
+/// Kinds of `MockHsm`-related errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    /// Access denied
+    AccessDenied,
+
+    /// Crypto error
+    CryptoError,
+
+    /// Object does not exist
+    ObjectNotFound,
+
+    /// Unsupported algorithm
+    UnsupportedAlgorithm,
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ErrorKind::AccessDenied => "access denied",
+            ErrorKind::CryptoError => "crypto error",
+            ErrorKind::ObjectNotFound => "object not found",
+            ErrorKind::UnsupportedAlgorithm => "unsupported algorithm",
+        })
+    }
+}

--- a/src/object.rs
+++ b/src/object.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod commands;
 mod entry;
+mod error;
 mod filter;
 pub(crate) mod generate;
 mod handle;
@@ -16,6 +17,7 @@ mod types;
 
 pub use self::{
     entry::Entry,
+    error::{Error, ErrorKind},
     filter::Filter,
     handle::Handle,
     info::Info,

--- a/src/object/error.rs
+++ b/src/object/error.rs
@@ -1,0 +1,27 @@
+use std::fmt;
+
+/// `Object`-related errors
+pub type Error = crate::Error<ErrorKind>;
+
+/// Kinds of `Object`-related errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum ErrorKind {
+    /// Invalid label
+    LabelInvalid,
+
+    /// Invalid object origin
+    OriginInvalid,
+
+    /// Invalid object type
+    TypeInvalid,
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ErrorKind::LabelInvalid => "invalid label",
+            ErrorKind::OriginInvalid => "invalid object origin",
+            ErrorKind::TypeInvalid => "invalid object type",
+        })
+    }
+}

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -87,18 +87,20 @@ impl Filter {
         Ok(match tag {
             0x01 => Filter::Id(read_be_bytes!(reader, u16)),
             0x02 => Filter::Type(
-                object::Type::from_u8(read_byte!(reader)).map_err(|e| err!(ProtocolError, e))?,
+                object::Type::from_u8(read_byte!(reader))
+                    .map_err(|e| format_err!(ProtocolError, e))?,
             ),
             0x03 => Filter::Domains(
                 Domain::from_bits(read_be_bytes!(reader, u16))
-                    .ok_or_else(|| err!(ProtocolError, "invalid domain bitflags"))?,
+                    .ok_or_else(|| format_err!(ProtocolError, "invalid domain bitflags"))?,
             ),
             0x04 => Filter::Capabilities(
                 Capability::from_bits(read_be_bytes!(reader, u64))
-                    .ok_or_else(|| err!(ProtocolError, "invalid capability bitflags"))?,
+                    .ok_or_else(|| format_err!(ProtocolError, "invalid capability bitflags"))?,
             ),
             0x05 => Filter::Algorithm(
-                Algorithm::from_u8(read_byte!(reader)).map_err(|e| err!(ProtocolError, e))?,
+                Algorithm::from_u8(read_byte!(reader))
+                    .map_err(|e| format_err!(ProtocolError, e))?,
             ),
             0x06 => {
                 let mut label_bytes = [0u8; LABEL_SIZE];

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -1,6 +1,6 @@
 //! Object labels: descriptions of objects
 
-use failure::{bail, format_err, Error};
+use super::{Error, ErrorKind};
 use std::{
     fmt::{self, Debug, Display},
     ops::{Deref, DerefMut},
@@ -20,7 +20,8 @@ impl Label {
     /// Create a new label from a slice, returning an error if it's over 40-bytes
     pub fn from_bytes(label_slice: &[u8]) -> Result<Self, Error> {
         if label_slice.len() > LABEL_SIZE {
-            bail!(
+            fail!(
+                ErrorKind::LabelInvalid,
                 "label too long: {}-bytes (max {})",
                 label_slice.len(),
                 LABEL_SIZE
@@ -38,7 +39,7 @@ impl Label {
             Some(pos) => &self.0[..pos],
             None => self.0.as_ref(),
         })
-        .map_err(|err| format_err!("{}", err))
+        .map_err(|err| format_err!(ErrorKind::LabelInvalid, "{}", err))
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,10 +1,14 @@
 //! Responses to command sent from the HSM.
 
 mod code;
+mod error;
 mod message;
 
-pub use self::code::Code;
 pub(crate) use self::message::Message;
+pub use self::{
+    code::Code,
+    error::{Error, ErrorKind},
+};
 use crate::command;
 #[cfg(feature = "mockhsm")]
 use crate::serialization::serialize;

--- a/src/response/error.rs
+++ b/src/response/error.rs
@@ -1,19 +1,19 @@
 use std::fmt;
 
-/// `Algorithm`-related errors
+/// Response-related errors
 pub type Error = crate::Error<ErrorKind>;
 
-/// Kinds of `Algorithm`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Kinds of response-related errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// Invalid algorithm tag
-    TagInvalid,
+    /// Invalid code
+    CodeInvalid,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            ErrorKind::TagInvalid => "invalid tag",
+            ErrorKind::CodeInvalid => "invalid code",
         })
     }
 }

--- a/src/response/message.rs
+++ b/src/response/message.rs
@@ -44,7 +44,8 @@ impl Message {
             );
         }
 
-        let code = response::Code::from_u8(bytes[0]).map_err(|e| err!(ProtocolError, "{}", e))?;
+        let code =
+            response::Code::from_u8(bytes[0]).map_err(|e| format_err!(ProtocolError, "{}", e))?;
 
         let mut length_bytes = [0u8; 2];
         length_bytes.copy_from_slice(&bytes[1..3]);

--- a/src/serialization/error.rs
+++ b/src/serialization/error.rs
@@ -1,42 +1,48 @@
 //! Serialization erros
 
-use failure::Fail;
-use serde;
+use serde::{de, ser};
 use std::{fmt, io};
 
 /// Serialization errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Serialization errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ErrorKind {
     /// Input/output errors
-    #[fail(display = "I/O error")]
     Io,
 
     /// Errors that occurred during Serde parsing
-    #[fail(display = "parse error")]
     Parse,
 
     /// Unexpected end-of-buffer/file
-    #[fail(display = "unexpected end of buffer")]
     UnexpectedEof,
 }
 
-impl serde::ser::Error for Error {
-    fn custom<T: fmt::Display>(msg: T) -> Self {
-        err!(ErrorKind::Parse, msg.to_string())
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ErrorKind::Io => "I/O error",
+            ErrorKind::Parse => "parse error",
+            ErrorKind::UnexpectedEof => "unexpected end of buffer",
+        })
     }
 }
 
-impl serde::de::Error for Error {
+impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        err!(ErrorKind::Parse, msg.to_string())
+        format_err!(ErrorKind::Parse, msg.to_string())
+    }
+}
+
+impl de::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        format_err!(ErrorKind::Parse, msg.to_string())
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        err!(ErrorKind::Io, err.to_string())
+        format_err!(ErrorKind::Io, err.to_string())
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -115,7 +115,7 @@ impl Session {
     pub fn messages_sent(&self) -> Result<usize, Error> {
         self.secure_channel
             .as_ref()
-            .ok_or_else(|| err!(ErrorKind::ClosedError, "session is already closed"))
+            .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed"))
             .map(SecureChannel::counter)
     }
 
@@ -263,7 +263,7 @@ impl Session {
     fn secure_channel(&mut self) -> Result<&mut SecureChannel, Error> {
         self.secure_channel
             .as_mut()
-            .ok_or_else(|| err!(ErrorKind::ClosedError, "session is already closed"))
+            .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed"))
     }
 }
 

--- a/src/session/message.rs
+++ b/src/session/message.rs
@@ -105,7 +105,7 @@ impl command::Message {
         }
 
         let command_type =
-            command::Code::from_u8(bytes[0]).map_err(|e| err!(ProtocolError, "{}", e))?;
+            command::Code::from_u8(bytes[0]).map_err(|e| format_err!(ProtocolError, "{}", e))?;
 
         let length = BigEndian::read_u16(&bytes[1..3]) as usize;
 
@@ -220,7 +220,7 @@ impl response::Message {
             );
         }
 
-        let code = response::Code::from_u8(bytes[0]).map_err(|e| err!(ProtocolError, "{}", e))?;
+        let code = response::Code::from_u8(bytes[0]).map_err(|e| format_err!(ProtocolError, "{}", e))?;
         let length = BigEndian::read_u16(&bytes[1..3]) as usize;
 
         if length.checked_add(3).unwrap() != bytes.len() {

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -143,7 +143,7 @@ impl SecureChannel {
 
         let id = response_message
             .session_id
-            .ok_or_else(|| err!(ErrorKind::CreateFailed, "no session ID in response"))?;
+            .ok_or_else(|| format_err!(ErrorKind::CreateFailed, "no session ID in response"))?;
 
         let session_response: CreateSessionResponse = deserialize(response_message.data.as_ref())?;
 
@@ -331,7 +331,7 @@ impl SecureChannel {
             .decrypt(&mut response_message)
             .map_err(|e| {
                 self.terminate();
-                err!(
+                format_err!(
                     ErrorKind::ProtocolError,
                     "error decrypting response: {:?}",
                     e
@@ -355,7 +355,7 @@ impl SecureChannel {
 
         let session_id = response.session_id.ok_or_else(|| {
             self.terminate();
-            err!(ErrorKind::ProtocolError, "no session ID in response")
+            format_err!(ErrorKind::ProtocolError, "no session ID in response")
         })?;
 
         if self.id != session_id {
@@ -458,7 +458,7 @@ impl SecureChannel {
             .decrypt(&mut command_data)
             .map_err(|e| {
                 self.terminate();
-                err!(
+                format_err!(
                     ErrorKind::ProtocolError,
                     "error decrypting command: {:?}",
                     e

--- a/src/setup/error.rs
+++ b/src/setup/error.rs
@@ -1,0 +1,34 @@
+use std::fmt;
+
+/// Setup-related errors
+pub type Error = crate::Error<ErrorKind>;
+
+/// Kinds of setup-related errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum ErrorKind {
+    /// Invalid label
+    LabelInvalid,
+
+    /// Errors involving setup report generation
+    ReportFailed,
+
+    /// Error performing setup
+    SetupFailed,
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ErrorKind::LabelInvalid => "invalid label",
+            ErrorKind::ReportFailed => "report failed",
+            ErrorKind::SetupFailed => "setup failed",
+        })
+    }
+}
+
+impl From<crate::client::Error> for Error {
+    fn from(client_error: crate::client::Error) -> Error {
+        // TODO(tarcieri): finer grained error reporting / ErrorKind mapping?
+        format_err!(ErrorKind::SetupFailed, "{}", client_error)
+    }
+}

--- a/src/setup/profile.rs
+++ b/src/setup/profile.rs
@@ -1,9 +1,7 @@
 //! Device provisioning profiles: all attributes required to initialize a device
 
-use super::role::Role;
-use super::Report;
+use super::{role::Role, Error, Report};
 use crate::{object, wrap, AuditOption, Client};
-use failure::Error;
 use std::time::Duration;
 
 /// Temporary account key to use for device provisioning.

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::new_without_default)]
 
+use super::{Error, ErrorKind};
 use crate::{
     device::SerialNumber,
     object, opaque,
@@ -11,7 +12,6 @@ use crate::{
     Capability, Client, Domain,
 };
 use chrono::{DateTime, Utc};
-use failure::{format_err, Error};
 use serde::{Deserialize, Serialize};
 use std::{env, str::FromStr};
 
@@ -84,7 +84,7 @@ impl Report {
                 opaque::Algorithm::Data,
                 self.to_json(),
             )
-            .map_err(|e| format_err!("{}", e))?;
+            .map_err(|e| format_err!(ErrorKind::ReportFailed, "{}", e))?;
 
         Ok(())
     }
@@ -95,7 +95,12 @@ impl FromStr for Report {
 
     /// Parse a `yubihsm::setup::Report` from its JSON serialization
     fn from_str(s: &str) -> Result<Self, Error> {
-        serde_json::from_str(s)
-            .map_err(|e| format_err!("error parsing yubihsm::setup::Report JSON: {}", e))
+        serde_json::from_str(s).map_err(|e| {
+            format_err!(
+                ErrorKind::ReportFailed,
+                "error parsing yubihsm::setup::Report JSON: {}",
+                e
+            )
+        })
     }
 }

--- a/src/setup/role.rs
+++ b/src/setup/role.rs
@@ -1,8 +1,8 @@
 //! Roles for interacting with the YubiHSM 2
 
+use super::{Error, ErrorKind};
 use crate::Client;
 pub use crate::{object, Capability, Credentials, Domain};
-use failure::{format_err, Error};
 
 /// Roles represent accounts on the device with specific permissions
 #[derive(Clone, Debug)]
@@ -74,7 +74,7 @@ impl Role {
                 Default::default(),
                 self.credentials.authentication_key.clone(),
             )
-            .map_err(|e| format_err!("error creating role: {}", e))?;
+            .map_err(|e| format_err!(ErrorKind::SetupFailed, "error creating role: {}", e))?;
 
         Ok(())
     }

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -3,8 +3,15 @@
 
 mod algorithm;
 pub(crate) mod commands;
+mod error;
 mod key;
 mod message;
 mod nonce;
 
-pub use self::{algorithm::Algorithm, key::Key, message::Message, nonce::Nonce};
+pub use self::{
+    algorithm::Algorithm,
+    error::{Error, ErrorKind},
+    key::Key,
+    message::Message,
+    nonce::Nonce,
+};

--- a/src/wrap/error.rs
+++ b/src/wrap/error.rs
@@ -1,19 +1,19 @@
 use std::fmt;
 
-/// `Algorithm`-related errors
+/// Wrap-related errors
 pub type Error = crate::Error<ErrorKind>;
 
-/// Kinds of `Algorithm`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Kinds of wrap-related errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// Invalid algorithm tag
-    TagInvalid,
+    /// Wrap message is an invalid length
+    LengthInvalid,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            ErrorKind::TagInvalid => "invalid tag",
+            ErrorKind::LengthInvalid => "invalid message length",
         })
     }
 }

--- a/src/wrap/message.rs
+++ b/src/wrap/message.rs
@@ -1,7 +1,7 @@
 //! Wrap messages
 
 use super::nonce::{self, Nonce};
-use failure::{bail, Error};
+use super::{Error, ErrorKind};
 use serde::{Deserialize, Serialize};
 
 /// Wrap wessage (encrypted HSM object or arbitrary data) encrypted under a wrap key
@@ -18,7 +18,11 @@ impl Message {
     /// Load a `Message` from a byte vector
     pub fn from_vec(mut vec: Vec<u8>) -> Result<Self, Error> {
         if vec.len() < nonce::SIZE {
-            bail!("message must be at least {}-bytes", nonce::SIZE);
+            fail!(
+                ErrorKind::LengthInvalid,
+                "message must be at least {}-bytes",
+                nonce::SIZE
+            );
         }
 
         let ciphertext = vec.split_off(nonce::SIZE);
@@ -55,7 +59,6 @@ impl Into<Vec<u8>> for Message {
         let mut vec = Vec::with_capacity(nonce::SIZE + ciphertext.len());
         vec.extend_from_slice(nonce.as_ref());
         vec.append(&mut ciphertext);
-
         vec
     }
 }


### PR DESCRIPTION
Replaces failure with direct impls of `std::error::Error` along with the `Display` trait.

Replaces previous uses of `bail!` and `failure::Error` with `fail!` and `ErrorKind` types for all of the crate's various subsystems.