### PR TITLE
v0.28.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.28.0] (2019-10-12)
+
+- Replace `gaunt` with `harp` ([#235])
+- Remove failure ([#234])
+- connector: Switch from `libusb` to `rusb` ([#232])
+- Upgrade to signatory v0.15 ([#231])
+
 ## [0.27.0] (2019-08-11)
 
 - Refactor `Algorithm` names to be camel case and subdivide RSA ([#228])
@@ -272,6 +279,11 @@ to adding support for several commands.
 
 - Initial release
 
+[0.28.0]: https://github.com/tendermint/yubihsm-rs/pull/236
+[#235]: https://github.com/tendermint/yubihsm-rs/pull/235
+[#234]: https://github.com/tendermint/yubihsm-rs/pull/234
+[#232]: https://github.com/tendermint/yubihsm-rs/pull/232
+[#231]: https://github.com/tendermint/yubihsm-rs/pull/231
 [0.27.0]: https://github.com/tendermint/yubihsm-rs/pull/229
 [#228]: https://github.com/tendermint/yubihsm-rs/pull/228
 [#227]: https://github.com/tendermint/yubihsm-rs/pull/227

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 USB-based access to the device. Supports most HSM functionality
                 including ECDSA, Ed25519, HMAC, and RSA.
                 """
-version       = "0.27.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.28.0" # Also update html_root_url in lib.rs when bumping this
 license       = "Apache-2.0 OR MIT"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 documentation = "https://docs.rs/yubihsm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.27.0"
+    html_root_url = "https://docs.rs/yubihsm/0.28.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Replace `gaunt` with `harp` (#235)
- Remove failure (#234)
- connector: Switch from `libusb` to `rusb` (#232)
- Upgrade to signatory v0.15 (#231)