### PR TITLE
Use Anomaly for error handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ jobs:
     - restore_cache:
         key: cache-2019-06-05-v0 # bump save_cache key below too
     - run:
-        name: Install Rust 1.36.0 # TODO: update Rust in the upstream Docker image
+        name: Install Rust 1.37.0 # TODO: update Rust in the upstream Docker image
         command: |
-          rustup toolchain install 1.36.0
-          rustup default 1.36.0
+          rustup toolchain install 1.37.0
+          rustup default 1.37.0
           rustup component add rustfmt
           rustup component add clippy
     - run:
@@ -79,8 +79,9 @@ jobs:
     - run:
         name: audit
         command: |
+          cargo install cargo-audit --force
           cargo audit --version
-          cargo audit
+          cargo audit --ignore RUSTSEC-2019-0031
     - save_cache:
         key: cache-2019-06-05-v0 # bump restore_cache key above too
         paths:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ circle-ci = { repository = "tendermint/yubihsm-rs", branch = "develop" }
 
 [dependencies]
 aes = "0.3"
+anomaly = "0.1.2"
 bitflags = "1"
 block-modes = "0.3"
 chrono = { version = "0.4", features=["serde"], optional = true }
@@ -39,6 +40,7 @@ sha2 = { version = "0.8", optional = true }
 signatory = { version = "0.17", features = ["digest", "ecdsa", "ed25519"] }
 signature = { version = "1.0.0-pre.1", features = ["derive-preview"] }
 subtle = "2"
+thiserror = "1"
 tiny_http = { version = "0.6", optional = true }
 uuid = { version = "0.8", default-features = false }
 zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or endorsed by Yubico (although whoever runs their Twitter account
 
 ## Prerequisites
 
-This crate builds on Rust 1.36+.
+Minimum Supported Rust Version: Rust 1.37+.
 
 On x86(-64) targets, add the following `RUSTFLAGS` to enable AES-NI to better
 secure communication with the YubiHSM:
@@ -173,7 +173,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [docs-image]: https://docs.rs/yubihsm/badge.svg
 [docs-link]: https://docs.rs/yubihsm/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.37+-blue.svg
 [build-image]: https://circleci.com/gh/tendermint/yubihsm-rs.svg?style=shield
 [build-link]: https://circleci.com/gh/tendermint/yubihsm-rs
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -5,6 +5,7 @@ mod error;
 pub use self::error::{Error, ErrorKind};
 
 use crate::{asymmetric, authentication, ecdh, ecdsa, hmac, opaque, otp, rsa, template, wrap};
+use anomaly::fail;
 
 /// Cryptographic algorithm types supported by the `YubiHSM 2`
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/algorithm/error.rs
+++ b/src/algorithm/error.rs
@@ -1,19 +1,22 @@
-use std::fmt;
+//! Algorithm errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// `Algorithm`-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of `Algorithm`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, Error, PartialEq, Debug)]
 pub enum ErrorKind {
     /// Invalid algorithm tag
+    #[error("invalid tag")]
     TagInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::TagInvalid => "invalid tag",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/asymmetric/algorithm.rs
+++ b/src/asymmetric/algorithm.rs
@@ -1,6 +1,7 @@
 //! Asymmetric algorithm support
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Asymmetric algorithms (RSA or ECC)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -4,7 +4,9 @@ pub(crate) mod commands;
 mod error;
 
 pub use self::error::{Error, ErrorKind};
+
 use crate::command;
+use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
 

--- a/src/audit/error.rs
+++ b/src/audit/error.rs
@@ -1,23 +1,26 @@
-use std::fmt;
+//! Audit errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// Audit-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of audit-related errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Invalid option
+    #[error("invalid option")]
     OptionInvalid,
 
     /// Invalid tag
+    #[error("invalid tag")]
     TagInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::OptionInvalid => "invalid option",
-            ErrorKind::TagInvalid => "invalid tag",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/authentication/algorithm.rs
+++ b/src/authentication/algorithm.rs
@@ -1,4 +1,7 @@
+//! Authentication algorithms
+
 use crate::algorithm;
+use anomaly::fail;
 
 /// Valid algorithms for auth keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/authentication/error.rs
+++ b/src/authentication/error.rs
@@ -1,19 +1,22 @@
-use std::fmt;
+//! Authentication errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// Authentication errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of authentication errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Key size is invalid
+    #[error("invalid key size")]
     KeySizeInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::KeySizeInvalid => "invalid key size",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/authentication/key.rs
+++ b/src/authentication/key.rs
@@ -1,6 +1,7 @@
 //! `YubiHSM 2` authentication keys (2 * AES-128 symmetric PSK) from which session keys are derived
 
 use super::{Error, ErrorKind};
+use anomaly::ensure;
 use getrandom::getrandom;
 #[cfg(feature = "hmac")]
 use hmac::Hmac;

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,82 +1,78 @@
 //! YubiHSM client errors
 
 use crate::{connector, device, serialization, session};
-use std::{fmt, io};
+use anomaly::{BoxError, Context};
+use std::io;
+use thiserror::Error;
 
 /// Client errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Client error kinds
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Couldn't authenticate session
+    #[error("authentication failed")]
     AuthenticationError,
 
     /// Session is closed
+    #[error("session closed")]
     ClosedSessionError,
 
     /// Errors with the connection to the HSM
-    ConnectorError {
-        /// Connection error kind
-        kind: connector::ErrorKind,
-    },
+    #[error("connector error")]
+    ConnectorError,
 
     /// Couldn't create session
+    #[error("couldn't create session")]
     CreateFailed,
 
     /// Errors originating in the HSM device
-    DeviceError {
-        /// HSM error kind
-        kind: device::ErrorKind,
-    },
+    #[error("HSM error")]
+    DeviceError,
 
     /// Protocol error occurred
+    #[error("protocol error")]
     ProtocolError,
 
     /// Error response from HSM we can't further specify
+    #[error("HSM response error")]
     ResponseError,
 }
 
-impl ErrorKind {
+impl Error {
     /// Get the device error, if this is a device error
-    pub fn device_error(self) -> Option<device::ErrorKind> {
-        match self {
-            ErrorKind::DeviceError { kind } => Some(kind),
-            _ => None,
+    pub fn device_error(&self) -> Option<device::ErrorKind> {
+        // TODO(tarcieri): eliminate unwraps or double check they will never panic
+        use std::error::Error;
+        if let Some(session_err) = self.source()?.downcast_ref::<session::Error>() {
+            session_err.source()?.downcast_ref().cloned()
+        } else {
+            None
         }
     }
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ErrorKind::AuthenticationError => f.write_str("authentication failed"),
-            ErrorKind::ClosedSessionError => f.write_str("session closed"),
-            ErrorKind::ConnectorError { kind } => write!(f, "connection error: {}", kind),
-            ErrorKind::CreateFailed => f.write_str("couldn't create session"),
-            ErrorKind::DeviceError { kind } => write!(f, "HSM error: {}", kind),
-            ErrorKind::ProtocolError => f.write_str("protocol error"),
-            ErrorKind::ResponseError => f.write_str("HSM error"),
-        }
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }
 
-// TODO: capture causes?
 impl From<connector::Error> for Error {
     fn from(err: connector::Error) -> Self {
-        let kind = ErrorKind::ConnectorError { kind: err.kind() };
-        format_err!(kind, "{}", err)
+        ErrorKind::ConnectorError.context(err).into()
     }
 }
 
-// TODO: capture causes?
 impl From<session::Error> for Error {
     fn from(err: session::Error) -> Self {
         let kind = match err.kind() {
             session::ErrorKind::AuthenticationError => ErrorKind::AuthenticationError,
             session::ErrorKind::ClosedError => ErrorKind::ClosedSessionError,
             session::ErrorKind::CreateFailed => ErrorKind::CreateFailed,
-            session::ErrorKind::DeviceError { kind } => ErrorKind::DeviceError { kind },
+            session::ErrorKind::DeviceError => ErrorKind::DeviceError,
             session::ErrorKind::ProtocolError
             | session::ErrorKind::CommandLimitExceeded
             | session::ErrorKind::MismatchError
@@ -84,20 +80,19 @@ impl From<session::Error> for Error {
             session::ErrorKind::ResponseError => ErrorKind::ResponseError,
         };
 
-        format_err!(kind, "{}", err)
+        kind.context(err).into()
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        format_err!(ErrorKind::ProtocolError, "{}", err)
+        ErrorKind::ProtocolError.context(err).into()
     }
 }
 
-// TODO: capture causes?
 impl From<serialization::Error> for Error {
     fn from(err: serialization::Error) -> Self {
-        format_err!(ErrorKind::ProtocolError, "{}", err)
+        ErrorKind::ProtocolError.context(err).into()
     }
 }
 

--- a/src/command/code.rs
+++ b/src/command/code.rs
@@ -1,6 +1,7 @@
 //! YubiHSM2 command codes
 
 use super::{Error, ErrorKind};
+use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 
 /// Command IDs for `YubiHSM 2` operations

--- a/src/command/error.rs
+++ b/src/command/error.rs
@@ -1,19 +1,22 @@
-use std::fmt;
+//! Command-related errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// Command-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of command-related errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Invalid code
+    #[error("invalid code")]
     CodeInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::CodeInvalid => "invalid code",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/command/message.rs
+++ b/src/command/message.rs
@@ -18,6 +18,9 @@ use crate::{
     },
     uuid::{self, Uuid},
 };
+use anomaly::ensure;
+#[cfg(any(feature = "http-server", feature = "mockhsm"))]
+use anomaly::{fail, format_err};
 
 /// A command sent from the host to the `YubiHSM 2`. May or may not be
 /// authenticated using SCP03's chained/evolving MAC protocol.

--- a/src/connector/http/server.rs
+++ b/src/connector/http/server.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     uuid,
 };
+use anomaly::format_err;
 use std::{io, process, time::Instant};
 use tiny_http as http;
 

--- a/src/connector/usb/connection.rs
+++ b/src/connector/usb/connection.rs
@@ -7,6 +7,7 @@ use crate::{
     command::MAX_MSG_SIZE,
     connector::{self, Connection, ErrorKind::UsbError, Message},
 };
+use anomaly::fail;
 use std::sync::Mutex;
 use uuid::Uuid;
 

--- a/src/connector/usb/device.rs
+++ b/src/connector/usb/device.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     device::SerialNumber,
 };
+use anomaly::{fail, format_err};
 use std::{
     fmt::{self, Debug},
     slice::Iter,

--- a/src/connector/usb/macros.rs
+++ b/src/connector/usb/macros.rs
@@ -22,21 +22,27 @@ macro_rules! usb_debug {
 /// Create `UsbError`s that include bus and address information
 macro_rules! usb_err {
     ($device:expr, $msg:expr) => {
-        format_err!(
-            UsbError,
-            "USB(bus={},addr={}): {}",
-            $device.bus_number(),
-            $device.address(),
-            $msg
-        );
+        {
+            use anomaly::format_err;
+            format_err!(
+                UsbError,
+                "USB(bus={},addr={}): {}",
+                $device.bus_number(),
+                $device.address(),
+                $msg
+            )
+        }
     };
     ($device:expr, $fmt:expr, $($arg:tt)+) => {
-        format_err!(
-            UsbError,
-            concat!("USB(bus={},addr={}): ", $fmt),
-            $device.bus_number(),
-            $device.address(),
-            $($arg)+
-        );
+        {
+            use anomaly::format_err;
+            format_err!(
+                UsbError,
+                concat!("USB(bus={},addr={}): ", $fmt),
+                $device.bus_number(),
+                $device.address(),
+                $($arg)+
+            )
+        }
     };
 }

--- a/src/device/serial.rs
+++ b/src/device/serial.rs
@@ -1,6 +1,7 @@
 //! YubiHSM 2 device serial numbers
 
 use super::error::{Error, ErrorKind};
+use anomaly::{fail, format_err};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display},

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -5,6 +5,8 @@
 mod error;
 
 pub use self::error::{Error, ErrorKind};
+
+use anomaly::fail;
 use bitflags::bitflags;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -1,19 +1,22 @@
-use std::fmt;
+//! Domain errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// Audit-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of audit-related errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Invalid domain
+    #[error("invalid domain")]
     DomainInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::DomainInvalid => "invalid domain",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/ecdh/algorithm.rs
+++ b/src/ecdh/algorithm.rs
@@ -1,6 +1,7 @@
 //! Key exchange algorithms
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Key exchange algorithms (a.k.a. Diffie-Hellman)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/ecdsa/algorithm.rs
+++ b/src/ecdsa/algorithm.rs
@@ -1,6 +1,7 @@
 //! ECDSA algorithms (i.e. hash functions)
 
 use crate::{algorithm, asymmetric};
+use anomaly::fail;
 use signatory::ecdsa::curve::{NistP256, NistP384, Secp256k1};
 
 /// Valid algorithms for asymmetric keys

--- a/src/ed25519/commands.rs
+++ b/src/ed25519/commands.rs
@@ -36,6 +36,6 @@ impl Response for SignEddsaResponse {
 
 impl SignEddsaResponse {
     pub(crate) fn signature(&self) -> Result<Signature, client::Error> {
-        Signature::from_bytes(&self.0).map_err(|e| format_err!(ResponseError, e))
+        Signature::from_bytes(&self.0).map_err(|e| ResponseError.context(e).into())
     }
 }

--- a/src/hmac/algorithm.rs
+++ b/src/hmac/algorithm.rs
@@ -1,6 +1,7 @@
 //! HMAC algorithms
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Valid algorithms for HMAC keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/mockhsm/connection.rs
+++ b/src/mockhsm/connection.rs
@@ -1,3 +1,6 @@
+//! Mock connection to the MockHSM
+
+use anomaly::{fail, format_err};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 

--- a/src/mockhsm/error.rs
+++ b/src/mockhsm/error.rs
@@ -1,31 +1,34 @@
-use std::fmt;
+//! MockHSM errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// `MockHsm`-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of `MockHsm`-related errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Access denied
+    #[error("access denied")]
     AccessDenied,
 
     /// Crypto error
+    #[error("crypto error")]
     CryptoError,
 
     /// Object does not exist
+    #[error("object not found")]
     ObjectNotFound,
 
     /// Unsupported algorithm
+    #[error("unsupported algorithm")]
     UnsupportedAlgorithm,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::AccessDenied => "access denied",
-            ErrorKind::CryptoError => "crypto error",
-            ErrorKind::ObjectNotFound => "object not found",
-            ErrorKind::UnsupportedAlgorithm => "unsupported algorithm",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/mockhsm/object/objects.rs
+++ b/src/mockhsm/object/objects.rs
@@ -8,6 +8,7 @@ use crate::{
     serialization::{deserialize, serialize},
     wrap, Algorithm, Capability, Domain,
 };
+use anomaly::{fail, format_err};
 use ring::aead::{self, AES_128_GCM, AES_256_GCM};
 use std::collections::{btree_map::Iter as BTreeMapIter, BTreeMap};
 

--- a/src/object/error.rs
+++ b/src/object/error.rs
@@ -1,27 +1,30 @@
-use std::fmt;
+//! Object errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// `Object`-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of `Object`-related errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Invalid label
+    #[error("invalid label")]
     LabelInvalid,
 
     /// Invalid object origin
+    #[error("invalid object origin")]
     OriginInvalid,
 
     /// Invalid object type
+    #[error("invalid object type")]
     TypeInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::LabelInvalid => "invalid label",
-            ErrorKind::OriginInvalid => "invalid object origin",
-            ErrorKind::TypeInvalid => "invalid object type",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/object/filter.rs
+++ b/src/object/filter.rs
@@ -1,13 +1,16 @@
 //! Filters for selecting objects in the list object command
 
+use crate::{algorithm::Algorithm, capability::Capability, client, domain::Domain, object};
+use std::io::Write;
+
 #[cfg(feature = "mockhsm")]
 use crate::client::ErrorKind::ProtocolError;
 #[cfg(feature = "mockhsm")]
 use crate::object::LABEL_SIZE;
-use crate::{algorithm::Algorithm, capability::Capability, client, domain::Domain, object};
+#[cfg(feature = "mockhsm")]
+use anomaly::{fail, format_err};
 #[cfg(feature = "mockhsm")]
 use std::io::Read;
-use std::io::Write;
 
 /// Filters to apply when listing objects
 pub enum Filter {

--- a/src/object/label.rs
+++ b/src/object/label.rs
@@ -1,6 +1,7 @@
 //! Object labels: descriptions of objects
 
 use super::{Error, ErrorKind};
+use anomaly::fail;
 use std::{
     fmt::{self, Debug, Display},
     ops::{Deref, DerefMut},
@@ -39,7 +40,7 @@ impl Label {
             Some(pos) => &self.0[..pos],
             None => self.0.as_ref(),
         })
-        .map_err(|err| format_err!(ErrorKind::LabelInvalid, "{}", err))
+        .map_err(|err| ErrorKind::LabelInvalid.context(err).into())
     }
 }
 

--- a/src/object/origins.rs
+++ b/src/object/origins.rs
@@ -1,6 +1,7 @@
 //! Information about where a key originates (i.e. where it was generated)
 
 use super::{Error, ErrorKind};
+use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 use std::fmt;
 

--- a/src/object/types.rs
+++ b/src/object/types.rs
@@ -1,6 +1,7 @@
 //! Types of objects
 
 use super::{Error, ErrorKind};
+use anomaly::fail;
 use serde::{de, ser, Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 

--- a/src/opaque/algorithm.rs
+++ b/src/opaque/algorithm.rs
@@ -1,6 +1,7 @@
 //! Pseudo-algorithms for opaque data
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Valid algorithms for opaque data
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/otp/algorithm.rs
+++ b/src/otp/algorithm.rs
@@ -1,6 +1,7 @@
 //! Yubico OTP algorithms
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Valid algorithms for Yubico OTP (AES-based one time password) keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/response/code.rs
+++ b/src/response/code.rs
@@ -2,6 +2,7 @@
 
 use super::{Error, ErrorKind};
 use crate::command;
+use anomaly::{fail, format_err};
 use serde::{de, ser, Deserialize, Serialize};
 
 /// Codes associated with HSM responses

--- a/src/response/error.rs
+++ b/src/response/error.rs
@@ -1,19 +1,22 @@
-use std::fmt;
+//! Response errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// Response-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of response-related errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
 pub enum ErrorKind {
     /// Invalid code
+    #[error("invalid code")]
     CodeInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::CodeInvalid => "invalid code",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/response/message.rs
+++ b/src/response/message.rs
@@ -4,8 +4,6 @@
 
 // TODO: this code predates the serde serializers. It could be rewritten with serde.
 
-#[cfg(feature = "mockhsm")]
-use crate::device;
 use crate::{
     command, connector, response,
     session::{
@@ -14,6 +12,10 @@ use crate::{
         ErrorKind::ProtocolError,
     },
 };
+use anomaly::{fail, format_err};
+
+#[cfg(feature = "mockhsm")]
+use crate::device;
 
 /// Command responses
 #[derive(Debug)]

--- a/src/rsa/algorithm.rs
+++ b/src/rsa/algorithm.rs
@@ -2,6 +2,7 @@
 
 use super::{oaep, pkcs1, pss};
 use crate::algorithm;
+use anomaly::fail;
 
 /// RSA algorithms (signing and encryption)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/mgf.rs
+++ b/src/rsa/mgf.rs
@@ -1,6 +1,7 @@
 //! Mask generating functions for use with RSASSA-PSS signatures
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Mask generating functions for RSASSA-PSS
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/oaep/algorithm.rs
+++ b/src/rsa/oaep/algorithm.rs
@@ -1,6 +1,7 @@
 //! RSA OAEP algorithms
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// RSA Optimal Asymmetric Encryption Padding (OAEP) algorithms
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/pkcs1/algorithm.rs
+++ b/src/rsa/pkcs1/algorithm.rs
@@ -1,6 +1,7 @@
 //! RSA PKCS#1v1.5 algorithms
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// RSA PKCS#1v1.5: legacy algorithms
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/rsa/pss/algorithm.rs
+++ b/src/rsa/pss/algorithm.rs
@@ -1,6 +1,7 @@
 //! RSASSA-PSS algorithms
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// RSASSA-PSS algorithms
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/serialization/error.rs
+++ b/src/serialization/error.rs
@@ -1,48 +1,50 @@
-//! Serialization erros
+//! Serialization errors
 
+use anomaly::{format_err, BoxError, Context};
 use serde::{de, ser};
 use std::{fmt, io};
+use thiserror::Error;
 
 /// Serialization errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Serialization errors
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Input/output errors
+    #[error("I/O error")]
     Io,
 
     /// Errors that occurred during Serde parsing
+    #[error("parse error")]
     Parse,
 
     /// Unexpected end-of-buffer/file
+    #[error("unexpected end of buffer")]
     UnexpectedEof,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::Io => "I/O error",
-            ErrorKind::Parse => "parse error",
-            ErrorKind::UnexpectedEof => "unexpected end of buffer",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }
 
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        format_err!(ErrorKind::Parse, msg.to_string())
+        format_err!(ErrorKind::Parse, msg.to_string()).into()
     }
 }
 
 impl de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        format_err!(ErrorKind::Parse, msg.to_string())
+        format_err!(ErrorKind::Parse, msg.to_string()).into()
     }
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        format_err!(ErrorKind::Io, err.to_string())
+        ErrorKind::Io.context(err).into()
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -28,6 +28,7 @@ use crate::{
     device, response,
     serialization::deserialize,
 };
+use anomaly::{ensure, fail, format_err};
 use std::{
     panic::{self, AssertUnwindSafe},
     time::{Duration, Instant},
@@ -115,7 +116,7 @@ impl Session {
     pub fn messages_sent(&self) -> Result<usize, Error> {
         self.secure_channel
             .as_ref()
-            .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed"))
+            .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed").into())
             .map(SecureChannel::counter)
     }
 
@@ -263,7 +264,7 @@ impl Session {
     fn secure_channel(&mut self) -> Result<&mut SecureChannel, Error> {
         self.secure_channel
             .as_mut()
-            .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed"))
+            .ok_or_else(|| format_err!(ErrorKind::ClosedError, "session is already closed").into())
     }
 }
 

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -1,75 +1,73 @@
 //! Session error types
 
 use crate::{connector, device, serialization};
-use std::fmt;
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// Session errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Session error kinds
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Couldn't authenticate session
+    #[error("authentication failed")]
     AuthenticationError,
 
     /// Session is closed
+    #[error("session closed")]
     ClosedError,
 
     /// Max command per session exceeded and a new session should be created
+    #[error("max commands per session exceeded")]
     CommandLimitExceeded,
 
     /// Couldn't create session
+    #[error("couldn't create session")]
     CreateFailed,
 
     /// Errors originating in the HSM device
-    DeviceError {
-        /// HSM error kind
-        kind: device::ErrorKind,
-    },
+    #[error("HSM error")]
+    DeviceError,
 
     /// Message was intended for a different session than the current one
+    #[error("session ID mismatch")]
     MismatchError,
 
     /// Protocol error occurred
+    #[error("protocol error")]
     ProtocolError,
 
     /// Error response from HSM we can't further specify
+    #[error("HSM response error")]
     ResponseError,
 
     /// MAC or cryptogram verify failed
+    #[error("cryptographic verification failed")]
     VerifyFailed,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ErrorKind::AuthenticationError => f.write_str("authentication failed"),
-            ErrorKind::ClosedError => f.write_str("session closed"),
-            ErrorKind::CommandLimitExceeded => f.write_str("max commands per session exceeded"),
-            ErrorKind::CreateFailed => f.write_str("couldn't create session"),
-            ErrorKind::DeviceError { kind } => write!(f, "HSM error: {}", kind),
-            ErrorKind::MismatchError => f.write_str("message has differing session ID"),
-            ErrorKind::ProtocolError => f.write_str("protocol error"),
-            ErrorKind::ResponseError => f.write_str("HSM error"),
-            ErrorKind::VerifyFailed => f.write_str("verification failed"),
-        }
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }
 
 impl From<connector::Error> for Error {
     fn from(err: connector::Error) -> Self {
-        format_err!(ErrorKind::ProtocolError, err.to_string())
+        ErrorKind::ProtocolError.context(err).into()
     }
 }
 
 impl From<device::ErrorKind> for Error {
     fn from(kind: device::ErrorKind) -> Self {
-        Error::new(ErrorKind::DeviceError { kind }, None)
+        ErrorKind::DeviceError.context(kind).into()
     }
 }
 
 impl From<serialization::Error> for Error {
     fn from(err: serialization::Error) -> Self {
-        format_err!(ErrorKind::ProtocolError, err.to_string())
+        ErrorKind::ProtocolError.context(err).into()
     }
 }

--- a/src/session/id.rs
+++ b/src/session/id.rs
@@ -1,6 +1,7 @@
 //! Session IDs: the YubiHSM2 supports up to 16 concurrent sessions.
 
 use super::{Error, ErrorKind::ProtocolError};
+use anomaly::fail;
 use std::fmt::{self, Display};
 
 /// Maximum session identifier

--- a/src/session/securechannel.rs
+++ b/src/session/securechannel.rs
@@ -46,6 +46,7 @@ use aes::{
     },
     Aes128,
 };
+use anomaly::{fail, format_err};
 use block_modes::{block_padding::Iso7816, BlockMode, Cbc};
 use cmac::{crypto_mac::Mac as CryptoMac, Cmac};
 use subtle::ConstantTimeEq;
@@ -733,7 +734,7 @@ mod tests {
         assert_eq!(host_channel.security_level, SecurityLevel::Terminated);
         assert_eq!(
             response.err().unwrap().to_string(),
-            "verification failed: R-MAC mismatch!"
+            "cryptographic verification failed: R-MAC mismatch!"
         );
     }
 }

--- a/src/session/securechannel/mac.rs
+++ b/src/session/securechannel/mac.rs
@@ -7,6 +7,7 @@
 //! lower (~2^32 messages).
 
 use crate::session;
+use anomaly::fail;
 use cmac::crypto_mac::generic_array::{typenum::U16, GenericArray};
 use std::fmt;
 use subtle::{Choice, ConstantTimeEq};

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -11,10 +11,12 @@ pub use self::{
     report::Report,
     role::Role,
 };
+
 use crate::{
     authentication::{self, Credentials, DEFAULT_AUTHENTICATION_KEY_ID},
     object, Capability, Client, Connector, Domain,
 };
+use anomaly::format_err;
 
 /// Label to place on the temporary setup auth key ID
 const SETUP_KEY_LABEL: &str = "yubihsm.rs temporary setup key";

--- a/src/setup/report.rs
+++ b/src/setup/report.rs
@@ -2,8 +2,6 @@
 //! provisioned, the username which performed the provisioning operation,
 //! and the date provisioning occurred.
 
-#![allow(clippy::new_without_default)]
-
 use super::{Error, ErrorKind};
 use crate::{
     device::SerialNumber,
@@ -11,6 +9,7 @@ use crate::{
     uuid::{self, Uuid},
     Capability, Client, Domain,
 };
+use anomaly::format_err;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{env, str::FromStr};
@@ -101,6 +100,7 @@ impl FromStr for Report {
                 "error parsing yubihsm::setup::Report JSON: {}",
                 e
             )
+            .into()
         })
     }
 }

--- a/src/setup/role.rs
+++ b/src/setup/role.rs
@@ -3,6 +3,7 @@
 use super::{Error, ErrorKind};
 use crate::Client;
 pub use crate::{object, Capability, Credentials, Domain};
+use anomaly::format_err;
 
 /// Roles represent accounts on the device with specific permissions
 #[derive(Clone, Debug)]

--- a/src/template/algorithm.rs
+++ b/src/template/algorithm.rs
@@ -1,6 +1,7 @@
 //! SSH certificate templates
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Template algorithms (for SSH)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/wrap/algorithm.rs
+++ b/src/wrap/algorithm.rs
@@ -1,6 +1,7 @@
 //! Wrap algorithms
 
 use crate::algorithm;
+use anomaly::fail;
 
 /// Valid algorithms for "wrap" (symmetric encryption/key wrapping) keys
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/wrap/error.rs
+++ b/src/wrap/error.rs
@@ -1,19 +1,22 @@
-use std::fmt;
+//! Key wrapping errors
+
+use anomaly::{BoxError, Context};
+use thiserror::Error;
 
 /// Wrap-related errors
 pub type Error = crate::Error<ErrorKind>;
 
 /// Kinds of wrap-related errors
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
 pub enum ErrorKind {
     /// Wrap message is an invalid length
+    #[error("invalid message length")]
     LengthInvalid,
 }
 
-impl fmt::Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ErrorKind::LengthInvalid => "invalid message length",
-        })
+impl ErrorKind {
+    /// Create an error context from this error
+    pub fn context(self, source: impl Into<BoxError>) -> Context<ErrorKind> {
+        Context::new(self, Some(source.into()))
     }
 }

--- a/src/wrap/key.rs
+++ b/src/wrap/key.rs
@@ -7,6 +7,7 @@
 // TODO(tarcieri): use this for `yubihsm::client::put_wrap_key` in general?
 
 use crate::{client, device, object, wrap, Capability, Client, Domain};
+use anomaly::fail;
 use getrandom::getrandom;
 use std::fmt::{self, Debug};
 use zeroize::{Zeroize, Zeroizing};

--- a/src/wrap/message.rs
+++ b/src/wrap/message.rs
@@ -2,6 +2,7 @@
 
 use super::nonce::{self, Nonce};
 use super::{Error, ErrorKind};
+use anomaly::fail;
 use serde::{Deserialize, Serialize};
 
 /// Wrap wessage (encrypted HSM object or arbitrary data) encrypted under a wrap key

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -111,7 +111,7 @@ pub fn clear_test_key_slot(client: &Client, object_type: object::Type) {
     if let Err(e) = client.delete_object(TEST_KEY_ID, object_type) {
         // Ignore errors for nonexistent objects. We're here to make sure the
         // slot is clear, so it's irrelevant if there was no obj to begin with
-        if e.kind().device_error() != Some(device::ErrorKind::ObjectNotFound) {
+        if e.device_error() != Some(device::ErrorKind::ObjectNotFound) {
             panic!("error clearing test key: {}", e);
         }
     }
@@ -120,7 +120,7 @@ pub fn clear_test_key_slot(client: &Client, object_type: object::Type) {
     match client.get_object_info(TEST_KEY_ID, object_type) {
         Ok(obj) => panic!("expected test key to be deleted! {:?}", obj),
         Err(e) => {
-            if e.kind().device_error() != Some(device::ErrorKind::ObjectNotFound) {
+            if e.device_error() != Some(device::ErrorKind::ObjectNotFound) {
                 panic!("error ensuring test key slot is clear: {}", e);
             }
         }


### PR DESCRIPTION
Removes previous bespoke error boilerplate and replaces it with Anomaly.

Eliminates all previous TODOs about capturing error contexts by using Anomaly to actually capture them.