### PR TITLE
v0.31.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.31.0] (2020-01-19)
+
+- Upgrade `signatory` to v0.18 ([#245])
+- Use Anomaly for error handling ([#244])
+
 ## [0.30.0] (2019-12-11)
 
 - Upgrade to `signatory` v0.17 ([#241])
@@ -287,6 +292,9 @@ to adding support for several commands.
 
 - Initial release
 
+[0.31.0]: https://github.com/tendermint/yubihsm-rs/pull/246
+[#245]: https://github.com/tendermint/yubihsm-rs/pull/245
+[#244]: https://github.com/tendermint/yubihsm-rs/pull/244
 [0.30.0]: https://github.com/tendermint/yubihsm-rs/pull/242
 [#241]: https://github.com/tendermint/yubihsm-rs/pull/241
 [0.29.0]: https://github.com/tendermint/yubihsm-rs/pull/239

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "yubihsm"
-version       = "0.30.0" # Also update html_root_url in lib.rs when bumping this
+version       = "0.31.0" # Also update html_root_url in lib.rs when bumping this
 description   = """
 Pure Rust client for YubiHSM2 devices with support for HTTP and
 USB-based access to the device. Supports most HSM functionality

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/yubihsm-rs/develop/img/logo.png",
-    html_root_url = "https://docs.rs/yubihsm/0.30.0"
+    html_root_url = "https://docs.rs/yubihsm/0.31.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
- Upgrade `signatory` to v0.18 (#245)
- Use `anomaly` for error handling (#244)